### PR TITLE
Investigate homepage not found error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,12 +9,7 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   experimental: {
-    allowedDevOrigins: [
-      '9000-firebase-studio-1752777808244.cluster-ve345ymguzcd6qqzuko2qbxtfe.cloudworkstations.dev',
-      'localhost:9000',
-      '127.0.0.1:9000',
-      '0.0.0.0:9000'
-    ],
+    // allowedDevOrigins is deprecated in Next.js 15
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
Remove deprecated `allowedDevOrigins` configuration from `next.config.ts` to resolve a warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ec3a691-c929-4412-8010-9ad65a12d1d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ec3a691-c929-4412-8010-9ad65a12d1d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>