### PR TITLE
feat(verify): guardar hash del certificado PDF para verificación por archivo

### DIFF
--- a/src/app/api/download-certificate/route.ts
+++ b/src/app/api/download-certificate/route.ts
@@ -1,4 +1,6 @@
+import { createHash } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
 import { adminDb } from '@/lib/firebase-admin';
 import { verifyAuthToken } from '@/lib/auth-helper';
 import { generateCertificatePDF } from '@/lib/certificate-generator';
@@ -78,10 +80,16 @@ export async function POST(request: NextRequest) {
 
     // Generar el certificado PDF
     const pdfBlob = await generateCertificatePDF(certificateData);
-    
+
     // Convertir Blob a Buffer
     const arrayBuffer = await pdfBlob.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
+
+    // Calcular hash del PDF y guardarlo para verificación posterior
+    const certificateHash = createHash('sha256').update(buffer).digest('hex');
+    messageRef.update({
+      certificateHashes: FieldValue.arrayUnion(certificateHash),
+    }).catch((e: any) => console.warn('⚠️ No se pudo guardar certificateHash:', e?.message));
 
     // Devolver el PDF como respuesta
     return new NextResponse(buffer, {

--- a/src/app/api/verify/route.ts
+++ b/src/app/api/verify/route.ts
@@ -93,11 +93,28 @@ async function queryByHashIndex(hash: string) {
       const doc = snapshot.docs[0];
       const attachment = findAttachmentByHash(doc, hash);
       if (attachment) {
-        return { doc, attachment };
+        return { doc, attachment, isCertificate: false };
       }
     }
   } catch (error) {
     console.warn("attachmentsHashes query failed:", error);
+  }
+  return null;
+}
+
+async function queryByCertificateHash(hash: string) {
+  try {
+    const snapshot = await adminDb
+      .collection("mail")
+      .where("certificateHashes", "array-contains", hash)
+      .limit(1)
+      .get();
+
+    if (!snapshot.empty) {
+      return { doc: snapshot.docs[0], attachment: null, isCertificate: true };
+    }
+  } catch (error) {
+    console.warn("certificateHashes query failed:", error);
   }
   return null;
 }
@@ -121,7 +138,7 @@ async function scanMailCollection(hash: string) {
     for (const doc of snapshot.docs) {
       const attachment = findAttachmentByHash(doc, hash);
       if (attachment) {
-        return { doc, attachment };
+        return { doc, attachment, isCertificate: false };
       }
     }
 
@@ -182,17 +199,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const quickMatch = await queryByHashIndex(hash);
-    const match = quickMatch || (await scanMailCollection(hash));
+    const quickMatch =
+      (await queryByHashIndex(hash)) ||
+      (await queryByCertificateHash(hash)) ||
+      (await scanMailCollection(hash));
 
-    if (!match) {
+    if (!quickMatch) {
       return NextResponse.json(
         { error: "Documento no encontrado", hash },
         { status: 404 }
       );
     }
 
-    const payload = buildResponsePayload(match.doc, match.attachment, hash);
+    const payload = buildResponsePayload(
+      quickMatch.doc,
+      quickMatch.attachment,
+      hash,
+      { isCertificateVerification: quickMatch.isCertificate }
+    );
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
Permite verificar certificados de lectura subiendo el PDF al portal de verificación.