### PR TITLE
fix: persist Hub invoice attempts

### DIFF
--- a/src/app/api/mercadopago/webhook/route.ts
+++ b/src/app/api/mercadopago/webhook/route.ts
@@ -66,7 +66,12 @@ export async function POST(request: NextRequest) {
         facturaId: billing.facturaId,
         alreadyIssued: billing.alreadyIssued,
       });
-    } else if (!billing.skipped) {
+    } else if (billing.skipped) {
+      console.warn('⚠️ Webhook: facturación Hub pendiente/omitida', {
+        paymentId,
+        reason: billing.reason,
+      });
+    } else {
       console.error('❌ Webhook: facturación Hub falló', {
         paymentId,
         error: billing.error,

--- a/src/app/api/process-payment/route.ts
+++ b/src/app/api/process-payment/route.ts
@@ -54,7 +54,12 @@ export async function POST(request: NextRequest) {
     }
 
     const billing = await requestHubInvoiceForMercadoPagoPayment(String(paymentId));
-    if (!billing.ok && !billing.skipped) {
+    if (!billing.ok && billing.skipped) {
+      console.warn('⚠️ process-payment: facturación Hub pendiente/omitida', {
+        paymentId,
+        reason: billing.reason,
+      });
+    } else if (!billing.ok) {
       console.error('❌ process-payment: facturación Hub falló', {
         paymentId,
         error: billing.error,

--- a/src/components/dashboard/wallet-client.tsx
+++ b/src/components/dashboard/wallet-client.tsx
@@ -44,6 +44,7 @@ export default function WalletClient({ user, transactions, planes }: WalletClien
   const [loadingPlan, setLoadingPlan] = useState<Plan['id'] | null>(null);
   const [syncOpId, setSyncOpId] = useState('');
   const [syncLoading, setSyncLoading] = useState(false);
+  const [invoiceLoadingId, setInvoiceLoadingId] = useState<string | null>(null);
   const [colegioPct, setColegioPct] = useState(0);
   const [colegioEligible, setColegioEligible] = useState(false);
   const [colegioNombre, setColegioNombre] = useState(COLEGIO_NOMBRE_FALLBACK_CLIENT);
@@ -339,6 +340,45 @@ export default function WalletClient({ user, transactions, planes }: WalletClien
     }
   };
 
+  const fetchInvoiceBlob = async (token: string, transactionId: string) => {
+    const res = await fetch(`/api/user/invoices/${encodeURIComponent(transactionId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      return { ok: true as const, blob: await res.blob() };
+    }
+
+    const data = await res.json().catch(() => ({}));
+    return {
+      ok: false as const,
+      status: res.status,
+      message:
+        typeof data.error === 'string'
+          ? data.error
+          : 'No se pudo descargar la factura.',
+    };
+  };
+
+  const retryInvoiceBilling = async (token: string, paymentId: string) => {
+    const res = await fetch('/api/process-payment', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ paymentId }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(
+        typeof data.error === 'string'
+          ? data.error
+          : 'No se pudo preparar la factura.',
+      );
+    }
+  };
+
   const handleDownloadInvoice = async (tx: Transaccion) => {
     const u = auth.currentUser;
     if (!u) {
@@ -351,18 +391,29 @@ export default function WalletClient({ user, transactions, planes }: WalletClien
     }
 
     try {
+      setInvoiceLoadingId(tx.id);
       const token = await u.getIdToken();
-      const res = await fetch(`/api/user/invoices/${encodeURIComponent(tx.id)}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(
-          typeof data.error === 'string' ? data.error : 'No se pudo descargar la factura.',
-        );
+      let invoice = await fetchInvoiceBlob(token, tx.id);
+
+      if (
+        !invoice.ok &&
+        invoice.status === 404 &&
+        invoice.message === 'La factura todavía no está disponible' &&
+        tx.paymentId
+      ) {
+        toast({
+          title: 'Preparando factura',
+          description: 'Reintentamos generar la factura y la descargamos cuando esté lista.',
+        });
+        await retryInvoiceBilling(token, tx.paymentId);
+        invoice = await fetchInvoiceBlob(token, tx.id);
       }
 
-      const blob = await res.blob();
+      if (!invoice.ok) {
+        throw new Error(invoice.message);
+      }
+
+      const blob = invoice.blob;
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       const pv = String(tx.billingHub?.ptoVta ?? 0).padStart(5, '0');
@@ -379,6 +430,8 @@ export default function WalletClient({ user, transactions, planes }: WalletClien
         description: error instanceof Error ? error.message : 'Probá de nuevo en un momento.',
         variant: 'destructive',
       });
+    } finally {
+      setInvoiceLoadingId(null);
     }
   };
 
@@ -386,7 +439,18 @@ export default function WalletClient({ user, transactions, planes }: WalletClien
     (a, b) => b.fecha.getTime() - a.fecha.getTime(),
   );
 
-  const canTryDownloadInvoice = (tx: Transaccion) => tx.tipo === 'compra';
+  const canTryDownloadInvoice = (tx: Transaccion) => tx.tipo === 'compra' && Boolean(tx.paymentId);
+
+  const invoiceStatusMessage = (tx: Transaccion) => {
+    const status = tx.billingHub?.status;
+    if (status === 'pending') {
+      return 'Factura pendiente de emisión. Podés reintentar desde Bajar factura.';
+    }
+    if (status === 'failed') {
+      return 'Factura no emitida automáticamente. Bajar factura reintenta el proceso.';
+    }
+    return null;
+  };
 
   return (
     <div className="space-y-5">
@@ -543,37 +607,58 @@ export default function WalletClient({ user, transactions, planes }: WalletClien
                         </TableCell>
                       </TableRow>
                     ) : (
-                      sortedTx.map((tx) => (
-                        <TableRow key={tx.id}>
-                          <TableCell>
-                            <FormattedDateCell date={tx.fecha} />
-                          </TableCell>
-                          <TableCell className="max-w-[360px]">
-                            <div className="font-medium leading-snug">{tx.descripcion}</div>
-                            {canTryDownloadInvoice(tx) ? (
-                              <button
-                                type="button"
-                                className="mt-1 inline-flex items-center gap-1 text-xs font-semibold text-primary underline-offset-2 hover:underline"
-                                onClick={() => void handleDownloadInvoice(tx)}
-                              >
-                                <Download className="h-3.5 w-3.5" />
-                                Bajar factura
-                              </button>
-                            ) : null}
-                          </TableCell>
-                          <TableCell>
-                            <Badge variant={tx.tipo === 'compra' ? 'default' : 'secondary'}>
-                              {tx.tipo.charAt(0).toUpperCase() + tx.tipo.slice(1)}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className={`font-bold ${tx.tipo === 'compra' ? 'text-green-600' : 'text-destructive'}`}>
-                            {tx.tipo === 'compra' ? `+${tx.creditos}` : tx.creditos}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            {tx.monto > 0 ? formatCurrency(tx.monto) : '-'}
-                          </TableCell>
-                        </TableRow>
-                      ))
+                      sortedTx.map((tx) => {
+                        const isInvoiceLoading = invoiceLoadingId === tx.id;
+                        const invoiceNotice = invoiceStatusMessage(tx);
+
+                        return (
+                          <TableRow key={tx.id}>
+                            <TableCell>
+                              <FormattedDateCell date={tx.fecha} />
+                            </TableCell>
+                            <TableCell className="max-w-[360px]">
+                              <div className="font-medium leading-snug">{tx.descripcion}</div>
+                              {canTryDownloadInvoice(tx) ? (
+                                <button
+                                  type="button"
+                                  className="mt-1 inline-flex items-center gap-1 text-xs font-semibold text-primary underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:no-underline"
+                                  onClick={() => void handleDownloadInvoice(tx)}
+                                  disabled={isInvoiceLoading}
+                                >
+                                  {isInvoiceLoading ? (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                  ) : (
+                                    <Download className="h-3.5 w-3.5" />
+                                  )}
+                                  {isInvoiceLoading ? 'Preparando factura' : 'Bajar factura'}
+                                </button>
+                              ) : null}
+                              {invoiceNotice ? (
+                                <p
+                                  className={`mt-1 text-xs ${
+                                    tx.billingHub?.status === 'failed'
+                                      ? 'text-destructive'
+                                      : 'text-muted-foreground'
+                                  }`}
+                                >
+                                  {invoiceNotice}
+                                </p>
+                              ) : null}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant={tx.tipo === 'compra' ? 'default' : 'secondary'}>
+                                {tx.tipo.charAt(0).toUpperCase() + tx.tipo.slice(1)}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className={`font-bold ${tx.tipo === 'compra' ? 'text-green-600' : 'text-destructive'}`}>
+                              {tx.tipo === 'compra' ? `+${tx.creditos}` : tx.creditos}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              {tx.monto > 0 ? formatCurrency(tx.monto) : '-'}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
                     )}
                   </TableBody>
                 </Table>

--- a/src/lib/notificas-hub-billing.ts
+++ b/src/lib/notificas-hub-billing.ts
@@ -32,6 +32,16 @@ type BillingHubResult =
   | { ok: false; skipped: true; reason: string }
   | { ok: false; skipped?: false; error: string; status?: number };
 
+type BillingHubPersistStatus = 'issued' | 'pending' | 'failed';
+
+type BillingHubSnapshot = {
+  id: string;
+  ref: {
+    set(data: Record<string, unknown>, options: { merge: boolean }): Promise<unknown>;
+  };
+  data(): Record<string, unknown>;
+};
+
 function billingEmitUrl(): string | undefined {
   const explicit =
     process.env.NOTIFICASHUB_BILLING_EMIT_URL ||
@@ -77,6 +87,80 @@ function asString(value: unknown): string | undefined {
 function digits(value: unknown, max = 32): string | undefined {
   const d = asString(value)?.replace(/\D/g, '').slice(0, max);
   return d || undefined;
+}
+
+function limitText(value: string | undefined, max = 500): string | null {
+  if (!value) return null;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function hubErrorMessage(json: Record<string, unknown>, status: number): string {
+  const explicit = asString(json.error) || asString(json.message);
+  if (explicit && !explicit.trimStart().startsWith('<!DOCTYPE html')) {
+    return explicit;
+  }
+  if (status === 404) {
+    return 'Endpoint de facturación del Hub no encontrado';
+  }
+  return `Hub respondió HTTP ${status}`;
+}
+
+function statusForHubReason(reason: string): BillingHubPersistStatus {
+  const normalized = reason.toLowerCase();
+  if (
+    normalized.includes('pending') ||
+    normalized.includes('not_ready') ||
+    normalized.includes('process') ||
+    normalized.includes('pendiente')
+  ) {
+    return 'pending';
+  }
+  return 'failed';
+}
+
+async function persistBillingHubAttempt(opts: {
+  paymentId: string;
+  transactionSnap: BillingHubSnapshot | null;
+  billingHub: Record<string, unknown> & { status: BillingHubPersistStatus };
+}) {
+  const { paymentId, transactionSnap, billingHub } = opts;
+  if (!transactionSnap) return;
+
+  const currentBillingHub = transactionSnap.data().billingHub as
+    | { status?: unknown }
+    | undefined;
+  if (billingHub.status !== 'issued' && currentBillingHub?.status === 'issued') {
+    return;
+  }
+
+  const db = getAdminDb();
+  await transactionSnap.ref.set({ billingHub }, { merge: true });
+  await db
+    .collection('user_transactions')
+    .doc(`mp_${paymentId}`)
+    .set({ billingHub }, { merge: true });
+}
+
+function buildBillingHubProblem(opts: {
+  status: BillingHubPersistStatus;
+  reason?: string;
+  error?: string;
+  httpStatus?: number;
+}) {
+  return {
+    status: opts.status,
+    facturaId: null,
+    cae: null,
+    caeFchVto: null,
+    voucherNumber: null,
+    ptoVta: null,
+    cbteTipo: null,
+    tipoComprobante: null,
+    reason: limitText(opts.reason),
+    error: limitText(opts.error),
+    httpStatus: opts.httpStatus ?? null,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
 }
 
 async function findSettledTransaction(payment: PaymentRecord) {
@@ -145,25 +229,52 @@ export async function requestHubInvoiceForMercadoPagoPayment(
     };
   }
 
+  const meta = metadataOf(payment);
+  const paymentIdStr = String(payment.id ?? paymentId);
+  const transactionSnap = (await findSettledTransaction(payment)) as BillingHubSnapshot | null;
+  const transaction = transactionSnap?.data() as Record<string, unknown> | undefined;
+
   if (payment.status !== 'approved') {
+    await persistBillingHubAttempt({
+      paymentId: paymentIdStr,
+      transactionSnap,
+      billingHub: buildBillingHubProblem({
+        status: 'pending',
+        reason: 'payment_not_approved',
+        error: asString(payment.status),
+      }),
+    });
     return { ok: false, skipped: true, reason: 'payment_not_approved' };
   }
 
-  const meta = metadataOf(payment);
   const shouldEmit =
     metaString(meta, 'hub_emit_factura') === 'true' ||
     process.env.MERCADOPAGO_HUB_EMIT_FACTURA === 'true' ||
     process.env.NOTIFICASHUB_BILLING_FORCE_EMIT === 'true';
   if (!shouldEmit) {
+    await persistBillingHubAttempt({
+      paymentId: paymentIdStr,
+      transactionSnap,
+      billingHub: buildBillingHubProblem({
+        status: 'failed',
+        reason: 'hub_emit_factura_not_enabled',
+      }),
+    });
     return { ok: false, skipped: true, reason: 'hub_emit_factura_not_enabled' };
   }
 
   if (!url || !secret) {
+    await persistBillingHubAttempt({
+      paymentId: paymentIdStr,
+      transactionSnap,
+      billingHub: buildBillingHubProblem({
+        status: 'failed',
+        reason: 'hub_billing_not_configured',
+      }),
+    });
     return { ok: false, skipped: true, reason: 'hub_billing_not_configured' };
   }
 
-  const transactionSnap = await findSettledTransaction(payment);
-  const transaction = transactionSnap?.data() as Record<string, unknown> | undefined;
   const userId = asString(transaction?.userId) || metaString(meta, 'user_id');
   const db = getAdminDb();
 
@@ -181,6 +292,14 @@ export async function requestHubInvoiceForMercadoPagoPayment(
         ? payment.transaction_amount
         : Number(metaString(meta, 'amount') ?? 0);
   if (!Number.isFinite(amount) || amount <= 0) {
+    await persistBillingHubAttempt({
+      paymentId: paymentIdStr,
+      transactionSnap,
+      billingHub: buildBillingHubProblem({
+        status: 'failed',
+        error: 'Importe inválido para facturación Hub',
+      }),
+    });
     return { ok: false, error: 'Importe inválido para facturación Hub' };
   }
 
@@ -191,7 +310,6 @@ export async function requestHubInvoiceForMercadoPagoPayment(
     typeof transaction?.credits === 'number'
       ? transaction.credits
       : Number(metaString(meta, 'credits') ?? 0);
-  const paymentIdStr = String(payment.id ?? paymentId);
 
   const payload = {
     idempotencyKey: `notificas_mp_${paymentIdStr}`,
@@ -240,6 +358,14 @@ export async function requestHubInvoiceForMercadoPagoPayment(
       body: JSON.stringify(payload),
     });
   } catch (error) {
+    await persistBillingHubAttempt({
+      paymentId: paymentIdStr,
+      transactionSnap,
+      billingHub: buildBillingHubProblem({
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'No se pudo contactar al Hub',
+      }),
+    });
     return {
       ok: false,
       error: error instanceof Error ? error.message : 'No se pudo contactar al Hub',
@@ -255,18 +381,37 @@ export async function requestHubInvoiceForMercadoPagoPayment(
   }
 
   if (!response.ok) {
+    const error = hubErrorMessage(json, response.status);
+    await persistBillingHubAttempt({
+      paymentId: paymentIdStr,
+      transactionSnap,
+      billingHub: buildBillingHubProblem({
+        status: 'failed',
+        error,
+        httpStatus: response.status,
+      }),
+    });
     return {
       ok: false,
       status: response.status,
-      error: asString(json.error) || `Hub respondió HTTP ${response.status}`,
+      error,
     };
   }
 
   if (json.ok === false) {
+    const reason = asString(json.status) || asString(json.message) || 'hub_invoice_not_ready';
+    await persistBillingHubAttempt({
+      paymentId: paymentIdStr,
+      transactionSnap,
+      billingHub: buildBillingHubProblem({
+        status: statusForHubReason(reason),
+        reason,
+      }),
+    });
     return {
       ok: false,
       skipped: true,
-      reason: asString(json.status) || asString(json.message) || 'hub_invoice_not_ready',
+      reason,
     };
   }
 
@@ -286,8 +431,10 @@ export async function requestHubInvoiceForMercadoPagoPayment(
     alreadyIssued: json.alreadyIssued === true,
   };
 
-  if (transactionSnap) {
-    const billingHub = {
+  await persistBillingHubAttempt({
+    paymentId: paymentIdStr,
+    transactionSnap,
+    billingHub: {
       status: 'issued',
       facturaId: result.facturaId ?? null,
       cae: result.CAE ?? null,
@@ -305,13 +452,8 @@ export async function requestHubInvoiceForMercadoPagoPayment(
       buyerDomicilio: payload.buyer.domicilio || null,
       alreadyIssued: result.alreadyIssued ?? false,
       updatedAt: FieldValue.serverTimestamp(),
-    };
-    await transactionSnap.ref.set({ billingHub }, { merge: true });
-    await db
-      .collection('user_transactions')
-      .doc(`mp_${paymentIdStr}`)
-      .set({ billingHub }, { merge: true });
-  }
+    },
+  });
 
   return result;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -109,6 +109,9 @@ export type Transaccion = {
       netoGravado?: number | null;
       iva?: number | null;
       total?: number | null;
+      reason?: string | null;
+      error?: string | null;
+      httpStatus?: number | null;
     };
 };
 


### PR DESCRIPTION
## Summary
- Persiste estados de facturación Hub fallidos o pendientes para que las compras no queden sin diagnóstico fiscal.
- Permite reintentar la emisión desde Billetera y mostrar estado de factura pendiente/fallida.
- Mejora logs de webhook y process-payment separando skips esperados de fallas reales.

## Test plan
- npm run typecheck
- npx eslint src/app/api/mercadopago/webhook/route.ts src/app/api/process-payment/route.ts src/components/dashboard/wallet-client.tsx src/lib/notificas-hub-billing.ts src/lib/types.ts --max-warnings 0
- npm run lint (falla por deuda existente en .claude/worktrees, fuera de este cambio)