### PR TITLE
fix(contactos): filtrar autocomplete y toast de borrador

### DIFF
--- a/src/components/dashboard/compose-message-dialog.tsx
+++ b/src/components/dashboard/compose-message-dialog.tsx
@@ -382,6 +382,7 @@ export function ComposeMessageDialog({ children, open, onOpenChange, user, initi
     const isExecutingRef = useRef(false);
     const currentExecutionIdRef = useRef<string | null>(null);
     const skipDraftSaveRef = useRef(false);
+    const showDraftSavedToastRef = useRef(false);
     const { toast } = useToast();
     const form = useForm<MessageFormValues>({
         resolver: zodResolver(messageSchema),
@@ -411,8 +412,8 @@ export function ComposeMessageDialog({ children, open, onOpenChange, user, initi
         void persistirContactoDestinatario(user.uid, email, phone || undefined);
     }, [form, user.uid]);
 
-    const saveDraftFromForm = useCallback(() => {
-        if (!user.uid) return;
+    const saveDraftFromForm = useCallback((): boolean => {
+        if (!user.uid) return false;
 
         if (document.activeElement instanceof HTMLElement) {
             document.activeElement.blur();
@@ -428,18 +429,27 @@ export function ComposeMessageDialog({ children, open, onOpenChange, user, initi
 
         if (hasComposeDraftContent(draft)) {
             writeComposeDraft(user.uid, draft);
-        } else {
-            clearComposeDraft(user.uid);
+            return true;
         }
+
+        clearComposeDraft(user.uid);
+        return false;
     }, [form, user.uid]);
 
     const handleOpenChange = useCallback((nextOpen: boolean) => {
         if (!nextOpen && !skipDraftSaveRef.current) {
-            saveDraftFromForm();
+            const saved = saveDraftFromForm();
+            if (saved && showDraftSavedToastRef.current) {
+                toast({
+                    title: "Mensaje guardado en borradores",
+                    description: "Tu mensaje no se borró. Podés retomarlo desde la carpeta Borradores.",
+                });
+            }
+            showDraftSavedToastRef.current = false;
         }
         skipDraftSaveRef.current = false;
         onOpenChange(nextOpen);
-    }, [onOpenChange, saveDraftFromForm]);
+    }, [onOpenChange, saveDraftFromForm, toast]);
 
     // Establecer contacto inicial o restaurar borrador local al abrir el diálogo
     useEffect(() => {
@@ -719,7 +729,12 @@ export function ComposeMessageDialog({ children, open, onOpenChange, user, initi
       <DialogTrigger asChild>
         {children}
       </DialogTrigger>
-      <DialogContent className="flex max-h-[92vh] w-[calc(100vw-1.5rem)] max-w-4xl flex-col gap-0 overflow-hidden p-0 top-[4vh] translate-y-0 sm:top-[50%] sm:translate-y-[-50%] sm:w-full">
+      <DialogContent
+        className="flex max-h-[92vh] w-[calc(100vw-1.5rem)] max-w-4xl flex-col gap-0 overflow-hidden p-0 top-[4vh] translate-y-0 sm:top-[50%] sm:translate-y-[-50%] sm:w-full"
+        onInteractOutside={() => {
+          showDraftSavedToastRef.current = true;
+        }}
+      >
         <DialogHeader className="shrink-0 space-y-3 border-b px-6 py-4 pr-12">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div className="space-y-1 text-left">

--- a/src/components/ui/email-autocomplete.tsx
+++ b/src/components/ui/email-autocomplete.tsx
@@ -39,6 +39,8 @@ export function EmailAutocomplete({
 
   // Buscar sugerencias cuando cambia el valor
   useEffect(() => {
+    let cancelled = false
+
     const searchSuggestions = async () => {
       if (!value || value.length < 2 || !userId) {
         setSuggestions([])
@@ -49,23 +51,33 @@ export function EmailAutocomplete({
       setIsLoading(true)
       try {
         const contactos = await buscarContactos(userId, value, 5)
-        // Filtrar sugerencias que ya coincidan exactamente con el valor actual
-        const filteredContactos = contactos.filter(contacto => 
-          contacto.email.toLowerCase() !== value.toLowerCase()
+        if (cancelled) return
+
+        const filteredContactos = contactos.filter(
+          (contacto) => contacto.email.toLowerCase() !== value.toLowerCase().trim()
         )
+
         setSuggestions(filteredContactos)
         setShowSuggestions(filteredContactos.length > 0)
       } catch (error) {
+        if (cancelled) return
         console.error('Error al buscar contactos:', error)
         setSuggestions([])
         setShowSuggestions(false)
       } finally {
-        setIsLoading(false)
+        if (!cancelled) setIsLoading(false)
       }
     }
 
-    const timeoutId = setTimeout(searchSuggestions, 300) // Debounce
-    return () => clearTimeout(timeoutId)
+    if (value.length >= 2) {
+      setShowSuggestions(false)
+    }
+
+    const timeoutId = setTimeout(searchSuggestions, 300)
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+    }
   }, [value, userId])
 
   // Cerrar sugerencias al hacer clic fuera

--- a/src/lib/contactos.ts
+++ b/src/lib/contactos.ts
@@ -172,13 +172,18 @@ export async function buscarContactos(
   try {
     const contactos = await obtenerContactos(usuarioId, 50); // Obtener más para filtrar
     
-    // Filtrar por término de búsqueda (email o nombre)
-    const terminoLower = termino.toLowerCase();
-    const contactosFiltrados = contactos.filter(contacto =>
-      contacto.email.toLowerCase().includes(terminoLower) ||
-      (contacto.nombre && contacto.nombre.toLowerCase().includes(terminoLower)) ||
-      (contacto.telefono && contacto.telefono.replace(/\D/g, '').includes(termino.replace(/\D/g, '')))
-    );
+    const terminoLower = termino.toLowerCase().trim();
+    const terminoDigits = termino.replace(/\D/g, '');
+
+    const contactosFiltrados = contactos.filter((contacto) => {
+      if (contacto.email.toLowerCase().includes(terminoLower)) return true;
+      if (contacto.nombre?.toLowerCase().includes(terminoLower)) return true;
+      // Solo filtrar por teléfono si el término incluye dígitos (evita que includes('') coincida con todos)
+      if (terminoDigits.length >= 2 && contacto.telefono) {
+        return contacto.telefono.replace(/\D/g, '').includes(terminoDigits);
+      }
+      return false;
+    });
     
     return contactosFiltrados.slice(0, limite);
   } catch (error) {


### PR DESCRIPTION
## Summary
- Corrige filtro de sugerencias al escribir destinatario (emails sin digitos ya no muestran todos los contactos con telefono)
- Cancela busquedas obsoletas en el autocomplete
- Muestra toast al guardar borrador al cerrar el dialogo con clic fuera

## Test plan
- [ ] Escribir email parcial en destinatario: solo aparecen contactos que coinciden
- [ ] Escribir email completo sin coincidencias: dropdown vacio
- [ ] Cerrar dialogo con clic fuera teniendo borrador: aparece toast de guardado

Made with [Cursor](https://cursor.com)