### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+`Notificas` — a single product (not a multi-product monorepo) with two deployable code units:
+- **Next.js 15 web app** (repo root, `src/`) — the product UI + ~55 API routes under `src/app/api/`. This is the main service.
+- **Firebase Cloud Functions** (`functions/`) — email send + open/click/read tracking, incoming email, WhatsApp webhook, scheduled blockchain-certify retries.
+
+Backing services are all Firebase (Firestore + Firebase Auth). There is no Docker/SQL. Project: `notificas-f9953`.
+
+### Running / testing (standard commands)
+Root app scripts live in `package.json`; functions scripts in `functions/package.json`.
+- Dev server: `npm run dev` → serves on **port 9006** (`next dev -p 9006`), not 9003.
+- Lint: `npm run lint`. Typecheck: `npm run typecheck`.
+- Functions unit tests: `cd functions && npm test` (Node `node --test`).
+
+### Non-obvious caveats
+- **`.env.local` is required to run the app and is gitignored**, so a fresh VM won't have it. Run `./setup-env-development.sh` to generate it with the public Firebase web config for `notificas-f9953` (the `NEXT_PUBLIC_FIREBASE_*` keys). Without these the client Firebase init logs an error in dev (and throws in production builds).
+- **The client does NOT use the Firebase emulators.** Despite `.idx/dev.nix` declaring `auth`/`firestore` emulators, `src/lib/firebase.ts` has no `connectAuthEmulator`/`connectFirestoreEmulator` wiring — client auth/Firestore always hit the **real** `notificas-f9953` project. So signing up/logging in in dev creates real records in that project.
+- **Server-side (admin) API routes need a service account** (`FIREBASE_CLIENT_EMAIL` + `FIREBASE_PRIVATE_KEY`, see `src/lib/firebase-admin.ts`). These are NOT in the public dev config, so admin-backed routes (e.g. `/api/auth/legacy-migration-state`, `/api/contact`, sending email) throw `Firebase Admin credentials are not fully configured.` Client-side auth + Firestore + the whole UI (landing, signup, login, dashboard) work fine without them. The signup flow tolerates the admin route 500ing and still creates the user client-side.
+- **Lint currently fails** (`npm run lint` uses `--max-warnings 0` and there are ~298 pre-existing errors, mostly in root-level `*.js` maintenance/test scripts and `any` usages). This is pre-existing, not caused by setup. `npm run typecheck` passes clean.
+- **Node:** functions require Node 22 (`functions/package.json` engines); the root app targets Node 20 in `.idx/dev.nix` but runs fine on Node 22.
+- Optional integrations (Polygon blockchain, Mercado Pago, WhatsApp, SMTP, Genkit/Gemini, LegalMev, Notificas Hub) each need their own secrets and are not required to run/test the core app.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Configuración del entorno de desarrollo para Cursor Cloud. No se modificó código de la aplicación; solo se agregó `AGENTS.md` con notas duraderas para futuros agentes.

## Qué se hizo
- Instalación de dependencias: `npm install` (raíz) y `npm install --prefix functions`.
- `.env.local` de desarrollo generado con la config pública de Firebase del proyecto `notificas-f9953` (archivo gitignored, no se commitea).
- Verificado: `npm run typecheck` (limpio), `cd functions && npm test` (12/12 OK), servidor `npm run dev` en puerto **9006**.
- `npm run lint` corre pero falla por ~298 errores **preexistentes** en scripts `*.js` de la raíz (no introducidos por esta configuración).

## Hello-world (funcionalidad central)
Registro de un usuario nuevo vía `/signup` (auth de Firebase del lado del cliente + doc en Firestore `users/{uid}`) con redirección al dashboard autenticado.

[notificas_signup_dashboard_demo.mp4](https://cursor.com/agents/bc-34376d1f-ce8f-417b-a189-bf96c6f68ca4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnotificas_signup_dashboard_demo.mp4)

[Landing de Notificas](https://cursor.com/agents/bc-34376d1f-ce8f-417b-a189-bf96c6f68ca4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page.webp)
[Dashboard tras el registro](https://cursor.com/agents/bc-34376d1f-ce8f-417b-a189-bf96c6f68ca4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_after_signup.webp)

## Notas para futuros agentes (ver `AGENTS.md`)
- El cliente NO usa emuladores; pega contra el proyecto real `notificas-f9953`.
- Rutas admin requieren service account (`FIREBASE_CLIENT_EMAIL`/`FIREBASE_PRIVATE_KEY`) no presente; el resto de la UI funciona sin ellas.
- `.env.local` es requerido y gitignored: regenerar con `./setup-env-development.sh`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34376d1f-ce8f-417b-a189-bf96c6f68ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34376d1f-ce8f-417b-a189-bf96c6f68ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

