### PR TITLE
API pública REST v1 para notificaciones certificadas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,16 @@ CONTACT_FORM_CREATED_BY=contact-form-web
 #
 # Opcional mapping cliente Hub: campo string hubBillingClienteId en users/{uid} o users/{uid}.perfil.hubBillingClienteId
 # = doc id en Firestore del Hub colección billing_recurrente_clients. Si omitís: se usa el Auth uid como doc id esperado.
+
+# ── API pública v1 (/api/v1) ─────────────────────────────────────────────────
+# Pepper para hashear API Keys. Si no está, se deriva de ADMIN_SESSION_SECRET.
+# PUBLIC_API_KEY_PEPPER=
+# Cifrado AES-GCM de secretos de webhook (whsec_). Si no está, se deriva igual.
+# PUBLIC_API_ENCRYPTION_KEY=
+# Rate limits por API Key / ventana de 60s
+# PUBLIC_API_RATE_LIMIT_GENERAL=120
+# PUBLIC_API_RATE_LIMIT_NOTIFICATIONS=30
+# PUBLIC_API_RATE_LIMIT_BATCHES=5
+# Allowlist sandbox (además de organizations.apiSandboxAllowlist)
+# PUBLIC_API_SANDBOX_ALLOWLIST_PHONES=+5491112345678
+# PUBLIC_API_SANDBOX_ALLOWLIST_EMAILS=dev@empresa.com

--- a/docs/examples/create-notification.mjs
+++ b/docs/examples/create-notification.mjs
@@ -1,0 +1,59 @@
+/**
+ * Ejemplo Node.js — send_certified_notification contra la API v1.
+ * Uso: NOTIFICAS_API_KEY=ntf_live_… node docs/examples/create-notification.mjs
+ */
+
+const API_URL = process.env.NOTIFICAS_API_URL || "https://notificas.com.ar";
+const API_KEY = process.env.NOTIFICAS_API_KEY;
+
+if (!API_KEY) {
+  console.error("Definí NOTIFICAS_API_KEY");
+  process.exit(1);
+}
+
+async function sendCertifiedNotification(input) {
+  const res = await fetch(`${API_URL}/api/v1/notifications`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": input.idempotencyKey,
+    },
+    body: JSON.stringify({
+      channel: input.channel,
+      recipient: input.recipient,
+      template: input.template,
+      variables: input.variables,
+      reference: input.reference,
+      metadata: input.metadata,
+    }),
+  });
+  const body = await res.json();
+  if (!res.ok) {
+    throw new Error(body?.error?.message || `HTTP ${res.status}`);
+  }
+  return body;
+}
+
+const result = await sendCertifiedNotification({
+  idempotencyKey: `cliente-123-20260827`,
+  channel: "whatsapp",
+  recipient: {
+    name: "Juan Pérez",
+    phone: "+5493364123456",
+    email: "juan@email.com",
+    document: "20123456789",
+  },
+  template: "notificacion_deuda_180_dias",
+  variables: {
+    nombre: "Juan Pérez",
+    dni: "20123456",
+    fecha: "27/08/2026",
+    monto: "125000",
+    cuotas: "4",
+  },
+  reference: "CLIENTE-12345",
+  metadata: { crm_id: "78482", account_id: "ABC123" },
+});
+
+console.log(result);

--- a/docs/examples/create-notification.py
+++ b/docs/examples/create-notification.py
@@ -1,0 +1,79 @@
+"""Ejemplo Python — send_certified_notification contra la API v1."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+API_URL = os.environ.get("NOTIFICAS_API_URL", "https://notificas.com.ar").rstrip("/")
+API_KEY = os.environ.get("NOTIFICAS_API_KEY")
+
+
+def send_certified_notification(
+    *,
+    channel: str,
+    recipient: dict,
+    template: str | None = None,
+    variables: dict | None = None,
+    reference: str | None = None,
+    metadata: dict | None = None,
+    idempotency_key: str,
+) -> dict:
+    if not API_KEY:
+        raise SystemExit("Definí NOTIFICAS_API_KEY")
+    payload = {
+        "channel": channel,
+        "recipient": recipient,
+        "template": template,
+        "variables": variables or {},
+        "reference": reference,
+        "metadata": metadata or {},
+    }
+    data = json.dumps({k: v for k, v in payload.items() if v is not None}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{API_URL}/api/v1/notifications",
+        data=data,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {API_KEY}",
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotency_key,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as res:
+            return json.loads(res.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        raise RuntimeError(body) from exc
+
+
+if __name__ == "__main__":
+    print(
+        json.dumps(
+            send_certified_notification(
+                channel="whatsapp",
+                recipient={
+                    "name": "Juan Pérez",
+                    "phone": "+5493364123456",
+                    "email": "juan@email.com",
+                    "document": "20123456789",
+                },
+                template="notificacion_deuda_180_dias",
+                variables={
+                    "nombre": "Juan Pérez",
+                    "dni": "20123456",
+                    "fecha": "27/08/2026",
+                    "monto": "125000",
+                    "cuotas": "4",
+                },
+                reference="CLIENTE-12345",
+                metadata={"crm_id": "78482", "account_id": "ABC123"},
+                idempotency_key="cliente-123-20260827",
+            ),
+            indent=2,
+            ensure_ascii=False,
+        )
+    )

--- a/docs/examples/create-notification.sh
+++ b/docs/examples/create-notification.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Ejemplo cURL — crear una notificación certificada (WhatsApp).
+# Reemplazá la API Key y, si corresponde, el template guardado en la organización.
+
+curl -X POST https://notificas.com.ar/api/v1/notifications \
+  -H "Authorization: Bearer ntf_live_xxxxxxxx" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: cliente-123-20260827" \
+  -H "X-Request-Id: req_client_123" \
+  -d '{
+    "channel": "whatsapp",
+    "recipient": {
+      "name": "Juan Pérez",
+      "phone": "+5493364123456",
+      "email": "juan@email.com",
+      "document": "20123456789"
+    },
+    "template": "notificacion_deuda_180_dias",
+    "variables": {
+      "nombre": "Juan Pérez",
+      "dni": "20123456",
+      "fecha": "27/08/2026",
+      "monto": "125000",
+      "cuotas": "4"
+    },
+    "reference": "CLIENTE-12345",
+    "metadata": {
+      "crm_id": "78482",
+      "account_id": "ABC123"
+    }
+  }'

--- a/docs/examples/embed.html
+++ b/docs/examples/embed.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Notificas — ejemplo de widget</title>
+  </head>
+  <body>
+    <h1>Insertar Notificas en una web</h1>
+    <p>
+      En producción reemplazá <code>data-demo="true"</code> por
+      <code>data-proxy-url="/api/notificas"</code> y serví el proxy de
+      <code>docs/examples/nextjs-proxy-route.ts</code> o
+      <code>docs/examples/express-proxy.js</code>.
+      No pongas una clave <code>ntf_live_</code> en el HTML.
+    </p>
+
+    <div
+      data-notificas-embed
+      data-demo="true"
+      data-channel="whatsapp"
+      data-template="notificacion_deuda_180_dias"
+      data-button-label="Enviar notificación certificada"
+    ></div>
+
+    <!-- En producción: https://notificas.com.ar/sdk/v1/notificas.js -->
+    <script src="https://notificas.com.ar/sdk/v1/notificas.js" async></script>
+  </body>
+</html>

--- a/docs/examples/express-proxy.js
+++ b/docs/examples/express-proxy.js
@@ -1,0 +1,70 @@
+/**
+ * Proxy Express: el navegador llama a /api/notificas/*
+ * y este middleware reenvía a https://notificas.com.ar/api/v1
+ * con la API key de servidor.
+ *
+ *   npm i express
+ *   NOTIFICAS_API_KEY=ntf_live_... node docs/examples/express-proxy.js
+ */
+const express = require("express");
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+
+const API_KEY = process.env.NOTIFICAS_API_KEY;
+const BASE = (process.env.NOTIFICAS_API_BASE || "https://notificas.com.ar/api/v1").replace(
+  /\/$/,
+  ""
+);
+const ALLOWED = new Set(["notifications", "batches", "me", "webhook-endpoints"]);
+
+app.use("/api/notificas", async (req, res) => {
+  if (!API_KEY) {
+    return res.status(500).json({
+      error: { code: "misconfigured", message: "Falta NOTIFICAS_API_KEY." },
+    });
+  }
+  const suffix = (req.path || "/").replace(/^\//, "");
+  const first = suffix.split("/")[0];
+  if (!ALLOWED.has(first)) {
+    return res.status(403).json({
+      error: { code: "forbidden_path", message: "Ruta no permitida." },
+    });
+  }
+
+  const url = new URL(`${BASE}/${suffix}`);
+  for (const [key, value] of Object.entries(req.query)) {
+    if (typeof value === "string") url.searchParams.set(key, value);
+  }
+
+  const headers = {
+    Authorization: `Bearer ${API_KEY}`,
+    Accept: "application/json",
+  };
+  if (req.headers["content-type"]) {
+    headers["Content-Type"] = req.headers["content-type"];
+  }
+  if (req.headers["idempotency-key"]) {
+    headers["Idempotency-Key"] = req.headers["idempotency-key"];
+  }
+
+  const init = { method: req.method, headers };
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = JSON.stringify(req.body ?? {});
+  }
+
+  const upstream = await fetch(url, init);
+  const text = await upstream.text();
+  res.status(upstream.status);
+  res.set("Content-Type", upstream.headers.get("content-type") || "application/json");
+  return res.send(text);
+});
+
+if (require.main === module) {
+  const port = Number(process.env.PORT || 8787);
+  app.listen(port, () => {
+    console.log(`Notificas proxy en http://localhost:${port}/api/notificas`);
+  });
+}
+
+module.exports = app;

--- a/docs/examples/nextjs-proxy-route.ts
+++ b/docs/examples/nextjs-proxy-route.ts
@@ -1,0 +1,85 @@
+/**
+ * Proxy Next.js App Router: el navegador llama a /api/notificas/*
+ * y este handler reenvía a la API pública de Notificas con la clave
+ * de servidor (nunca expuesta al frontend).
+ *
+ * Guardá este archivo en tu proyecto como:
+ *   app/api/notificas/[...path]/route.ts
+ *
+ * Env:
+ *   NOTIFICAS_API_KEY=ntf_live_...
+ *   NOTIFICAS_API_BASE=https://notificas.com.ar/api/v1
+ */
+import { NextRequest, NextResponse } from "next/server";
+
+const ALLOWED_PREFIXES = [
+  "notifications",
+  "batches",
+  "me",
+  "webhook-endpoints",
+];
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxy(request, context);
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxy(request, context);
+}
+
+async function proxy(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  const apiKey = process.env.NOTIFICAS_API_KEY;
+  const base = (process.env.NOTIFICAS_API_BASE ?? "https://notificas.com.ar/api/v1").replace(
+    /\/$/,
+    ""
+  );
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: { code: "misconfigured", message: "Falta NOTIFICAS_API_KEY." } },
+      { status: 500 }
+    );
+  }
+
+  const { path } = await context.params;
+  const segments = path ?? [];
+  const first = segments[0] ?? "";
+  if (!ALLOWED_PREFIXES.includes(first)) {
+    return NextResponse.json(
+      { error: { code: "forbidden_path", message: "Ruta no permitida." } },
+      { status: 403 }
+    );
+  }
+
+  const search = request.nextUrl.search;
+  const target = `${base}/${segments.map(encodeURIComponent).join("/")}${search}`;
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${apiKey}`);
+  headers.set("Accept", "application/json");
+  const contentType = request.headers.get("content-type");
+  if (contentType) headers.set("Content-Type", contentType);
+  const idempotency = request.headers.get("Idempotency-Key");
+  if (idempotency) headers.set("Idempotency-Key", idempotency);
+
+  const init: RequestInit = { method: request.method, headers };
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = await request.text();
+  }
+
+  const upstream = await fetch(target, init);
+  const body = await upstream.text();
+  return new NextResponse(body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("content-type") ?? "application/json",
+    },
+  });
+}

--- a/docs/examples/verify-webhook.py
+++ b/docs/examples/verify-webhook.py
@@ -1,0 +1,46 @@
+"""Cómo verificar la firma de un webhook de Notificas (HMAC-SHA256)."""
+
+import hashlib
+import hmac
+import json
+import time
+
+
+def verify_notificas_signature(
+    *,
+    secret: str,
+    event_id: str,
+    timestamp: str,
+    raw_body: bytes,
+    signature_header: str,
+    max_skew_seconds: int = 300,
+) -> bool:
+    try:
+        ts = int(timestamp)
+    except ValueError:
+        return False
+    if abs(time.time() - ts) > max_skew_seconds:
+        return False
+    provided = signature_header.strip()
+    if provided.startswith("v1="):
+        provided = provided[3:]
+    payload = f"{event_id}.{timestamp}.{raw_body.decode('utf-8')}".encode("utf-8")
+    expected = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, provided.lower())
+
+
+if __name__ == "__main__":
+    body = json.dumps(
+        {
+            "id": "evt_01EXAMPLE",
+            "type": "notification.delivered",
+            "created_at": "2026-08-27T13:15:00Z",
+            "data": {
+                "notification_id": "ntf_01EXAMPLE",
+                "reference": "CLIENTE-12345",
+                "status": "delivered",
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    print("Usá el raw body exacto (bytes) que recibió tu servidor, no un JSON re-serializado.")

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -67,7 +67,7 @@ Una clave revocada responde `401` con `code: revoked_api_key`.
 
 ## Endpoints
 
-Ver OpenAPI en `/openapi/v1.yaml` y UI en `/docs/api`.
+Ver OpenAPI en `/openapi/v1.yaml` y UI en `/docs/api`. Widget/SDK para sitios: `/docs/api/embed` (`https://notificas.com.ar/sdk/v1/notificas.js`).
 
 | Método | Endpoint | Función |
 |--------|----------|---------|
@@ -173,6 +173,44 @@ No hace falta agregar secretos nuevos a `apphosting.yaml` para el primer deploy.
 5. Probar `GET https://notificas.com.ar/api/v1/me` y `GET https://notificas.com.ar/docs/api`.
 
 Índices nuevos tardan en habilitarse; el listado puede fallar hasta que Firestore los construya.
+
+## Insertar la API en una web (SDK)
+
+Script público: `https://notificas.com.ar/sdk/v1/notificas.js`.
+
+**No pongas `ntf_live_…` en el HTML.** El widget o el cliente JS deben usar `proxyUrl` hacia un backend tuyo que agregue `Authorization: Bearer`. Una clave `ntf_live_` en el navegador lanza error salvo `allowBrowserKey: true` (solo para pruebas internas).
+
+Widget (copy-paste):
+
+```html
+<div
+  data-notificas-embed
+  data-proxy-url="/api/notificas"
+  data-channel="whatsapp"
+  data-template="notificacion_deuda_180_dias"
+></div>
+<script src="https://notificas.com.ar/sdk/v1/notificas.js" async></script>
+```
+
+Cliente:
+
+```js
+const client = Notificas.create({ proxyUrl: "/api/notificas" });
+await client.sendCertifiedNotification({
+  channel: "whatsapp",
+  recipient: { name: "Ana Pérez", phone: "+5491112345678" },
+  template: "notificacion_deuda_180_dias",
+  variables: { nombre: "Ana Pérez", monto: "128400" },
+});
+```
+
+El proxy reenvía `/api/notificas/*` → `https://notificas.com.ar/api/v1/*`. Ejemplos:
+
+- `docs/examples/nextjs-proxy-route.ts`
+- `docs/examples/express-proxy.js`
+- `docs/examples/embed.html`
+
+Demo sin API: `Notificas.embed("#el", { demo: true })` o `data-demo="true"`.
 
 ## Preparado para agentes / iPaaS
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,179 @@
+# API pública v1 de Notificas
+
+Infraestructura B2B para generar y consultar notificaciones digitales certificadas y trazables desde sistemas de terceros (CRM, ERP, cobranzas, estudios jurídicos, agentes).
+
+La API **no duplica** la lógica de envío. Reutiliza `mail`, Cloud Function `sendEmail`, campañas, evidencia, PDFs, hashes y estados existentes.
+
+Flujo:
+
+```
+Sistema del cliente → API Notificas → canal (WhatsApp / email)
+  → evidencia (snapshot, constancia, Polygon) → webhook / GET → sistema del cliente
+```
+
+## Arquitectura
+
+- Next.js 15 App Router, rutas en `/api/v1/*` (versionables: un futuro `/api/v2` no rompe v1).
+- Autenticación por API Key de empresa (`organizations/{orgId}`).
+- Tenant = organización. Toda consulta filtra por `orgId` de la clave. Un ID ajeno responde **404**, no 403, para no filtrar existencia.
+- Envío individual: `createMailDocumentAdmin` + worker interno que llama `invokeSendEmail` (misma CF que el compose y las campañas).
+- Lotes: crea una `campaigns` con `apiSource=public_api` y reutiliza fanout + Cloud Tasks + worker.
+- Sandbox (`ntf_test_…`): no despacha a Meta/Resend salvo allowlist. Usa el flag `simulated` ya existente.
+- Webhooks salientes: HMAC-SHA256, reintentos con backoff vía Cloud Tasks, mismo `event_id`.
+
+Colecciones (solo Admin SDK; Firestore rules `allow read, write: if false`):
+
+| Colección | Uso |
+|-----------|-----|
+| `api_keys` | metadatos + hash de la clave |
+| `api_notifications` | índice público → `mailId` |
+| `api_batches` | índice público → `campaignId` |
+| `api_idempotency` | Idempotency-Key por org+ambiente |
+| `api_audit_logs` | traza sin secretos |
+| `api_rate_limits` | ventanas por API Key |
+| `webhook_endpoints` | URLs + secret cifrado |
+| `webhook_events` / `webhook_deliveries` | eventos y reintentos |
+
+## Autenticación
+
+Header:
+
+```
+Authorization: Bearer ntf_live_xxxxxxxx
+```
+
+o `ntf_test_xxxxxxxx` para sandbox.
+
+**Nunca** se guarda la clave completa. Se persiste: `id`, `prefix` visible, `keyHash` (SHA-256 con pepper), `orgId`, scopes, ambiente, estado, fechas.
+
+### Cómo generar una API Key
+
+1. Panel admin: `/admin/api-keys` (sesión del panel).
+2. Script:
+
+```bash
+npx tsx scripts/create-api-key.ts --orgId ORG_ID --name "CRM cobranzas" --env live
+```
+
+El secret se muestra **una sola vez**.
+
+### Cómo revocarla
+
+- Panel admin → Revocar.
+- `DELETE /api/admin/api-keys?keyId=key_…&orgId=…`
+- Script: `npx tsx scripts/create-api-key.ts --revoke key_… --orgId ORG_ID`
+
+Una clave revocada responde `401` con `code: revoked_api_key`.
+
+## Endpoints
+
+Ver OpenAPI en `/openapi/v1.yaml` y UI en `/docs/api`.
+
+| Método | Endpoint | Función |
+|--------|----------|---------|
+| GET | `/api/v1/me` | Cuenta y ambiente de la clave |
+| POST | `/api/v1/notifications` | Crear notificación |
+| GET | `/api/v1/notifications` | Listar (cursor) |
+| GET | `/api/v1/notifications/{id}` | Consultar |
+| GET | `/api/v1/notifications/{id}/certificate` | Constancia de envío (URL firmada 15 min) |
+| POST | `/api/v1/batches` | Envío masivo asíncrono |
+| GET | `/api/v1/batches/{id}` | Estado del lote |
+| POST | `/api/v1/webhook-endpoints` | Registrar webhook |
+| GET | `/api/v1/webhook-endpoints` | Listar |
+| GET/PATCH/DELETE | `/api/v1/webhook-endpoints/{id}` | Gestionar / desactivar |
+
+Workers internos (secret `CAMPAIGN_WORKER_SECRET`, no públicos):
+
+- `POST /api/internal/public-api/send`
+- `POST /api/internal/public-api/webhook-deliver`
+
+## Idempotency
+
+Header `Idempotency-Key` (1–256 chars). Misma empresa + ambiente + key + mismo body → respuesta original. Mismo key + body distinto → `409 idempotency_key_reused`.
+
+## Estados (capa de normalización)
+
+No se inventan hechos. Mapeo sobre `mail.delivery`, `mail.transport`, tracking WhatsApp y `campaign_messages`:
+
+| API | Significado técnico |
+|-----|---------------------|
+| queued | Documentada, pendiente de despacho |
+| processing | Envío en curso |
+| sent | El proveedor aceptó el envío (SMTP/Meta) |
+| delivered | Meta `delivered` o transporte `delivered` |
+| read | Meta `read`, confirmación de lectura o apertura del lector |
+| failed | Error de envío, bounce o fallo Meta |
+
+La constancia de envío **no** es certificado de lectura, firma digital, documento público ni carta documento.
+
+## Sandbox
+
+Claves `ntf_test_`. No generan comunicaciones reales salvo que el destinatario esté en:
+
+- `organizations.apiSandboxAllowlist.phones` / `.emails`
+- o env `PUBLIC_API_SANDBOX_ALLOWLIST_PHONES` / `PUBLIC_API_SANDBOX_ALLOWLIST_EMAILS`
+
+Respuestas incluyen `test_mode: true`.
+
+## Webhooks
+
+Eventos: `notification.queued|sent|delivered|read|failed`, `notification.certificate_ready`, `batch.completed`.
+
+Firma:
+
+```
+signed_payload = event_id + "." + timestamp + "." + rawBody
+notificas-signature: v1=<HMAC_SHA256_hex(secret, signed_payload)>
+```
+
+Headers: `notificas-id`, `notificas-timestamp`, `notificas-signature`.
+
+Rechazar si `|now - timestamp| > 300s` (replay). Los reintentos reenvían el **mismo** `id` de evento.
+
+Backoff (segundos): 0, 60, 300, 1800, 7200, 21600, 86400. Se reintenta en timeout, red y HTTP 5xx/408/429.
+
+SSRF: se bloquean localhost, IPs privadas, metadata cloud; HTTPS obligatorio en live/producción.
+
+## Rate limits
+
+Por API Key (no globales), ventana 60s, configurable:
+
+| Bucket | Env | Default |
+|--------|-----|---------|
+| general | `PUBLIC_API_RATE_LIMIT_GENERAL` | 120 |
+| notifications | `PUBLIC_API_RATE_LIMIT_NOTIFICATIONS` | 30 |
+| batches | `PUBLIC_API_RATE_LIMIT_BATCHES` | 5 |
+
+HTTP 429 + `Retry-After`.
+
+## Trazabilidad / auditoría
+
+Cada request tiene `X-Request-Id`. `api_audit_logs` guarda: apiKeyId, orgId, path, status, duración, notification/batch id. **Nunca** Authorization, secrets ni bodies crudos.
+
+Cadena: `X-Request-Id` → `api_notifications.requestId` → `mail.requestId` → WAMID / Message-ID → evidencia.
+
+## Variables de entorno
+
+Ver `.env.example`. Nuevas (opcionales; hay fallback a secretos ya existentes):
+
+- `PUBLIC_API_KEY_PEPPER`
+- `PUBLIC_API_ENCRYPTION_KEY` (AES-GCM de `whsec_`)
+- `PUBLIC_API_RATE_LIMIT_*`
+- `PUBLIC_API_SANDBOX_ALLOWLIST_PHONES`
+- `PUBLIC_API_SANDBOX_ALLOWLIST_EMAILS`
+
+No hace falta agregar secretos nuevos a `apphosting.yaml` para el primer deploy. Si querés pepper/cifrado dedicados, creá los secretos en Secret Manager y referencialos después.
+
+## Deploy
+
+1. Merge a `main` (o la rama de App Hosting).
+2. `firebase deploy --only firestore:indexes,firestore:rules`
+3. App Hosting rebuild (el backend `notificas` ya apunta a este repo).
+4. Generar una API Key de prueba desde `/admin/api-keys`.
+5. Probar `GET https://notificas.com.ar/api/v1/me` y `GET https://notificas.com.ar/docs/api`.
+
+Índices nuevos tardan en habilitarse; el listado puede fallar hasta que Firestore los construya.
+
+## Preparado para agentes / iPaaS
+
+El contrato de `POST /notifications` es deliberadamente plano (`channel`, `recipient`, `template`, `variables`, `reference`, `metadata`) para un tool tipo `send_certified_notification` en Meta Business Agents, OpenAI, MCP, Zapier, Make o n8n. No hay adaptadores de esos vendors en este cambio.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -191,6 +191,83 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "api_keys",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "keyHash", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "api_keys",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "orgId", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "api_notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "orgId", "order": "ASCENDING" },
+        { "fieldPath": "testMode", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "api_notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "orgId", "order": "ASCENDING" },
+        { "fieldPath": "testMode", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "api_notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "orgId", "order": "ASCENDING" },
+        { "fieldPath": "testMode", "order": "ASCENDING" },
+        { "fieldPath": "channel", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "api_notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "orgId", "order": "ASCENDING" },
+        { "fieldPath": "testMode", "order": "ASCENDING" },
+        { "fieldPath": "reference", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "api_notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "orgId", "order": "ASCENDING" },
+        { "fieldPath": "testMode", "order": "ASCENDING" },
+        { "fieldPath": "recipientSearch", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "webhook_endpoints",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "orgId", "order": "ASCENDING" },
+        { "fieldPath": "environment", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -305,6 +305,17 @@ service cloud.firestore {
       allow create: if signedIn() && request.resource.data.userId == request.auth.uid;
     }
 
+    // API pública v1: solo Admin SDK (API keys, notificaciones, webhooks, auditoría).
+    match /api_keys/{id} { allow read, write: if false; }
+    match /api_notifications/{id} { allow read, write: if false; }
+    match /api_batches/{id} { allow read, write: if false; }
+    match /api_idempotency/{id} { allow read, write: if false; }
+    match /api_audit_logs/{id} { allow read, write: if false; }
+    match /api_rate_limits/{id} { allow read, write: if false; }
+    match /webhook_endpoints/{id} { allow read, write: if false; }
+    match /webhook_events/{id} { allow read, write: if false; }
+    match /webhook_deliveries/{id} { allow read, write: if false; }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,25 @@ const nextConfig: NextConfig = {
         destination: "https://notificas.com.ar/:path*",
         permanent: true,
       },
+      {
+        source: "/integrar",
+        destination: "/docs/api/embed",
+        permanent: false,
+      },
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: "/sdk/v1/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, stale-while-revalidate=86400",
+          },
+          { key: "Access-Control-Allow-Origin", value: "*" },
+        ],
+      },
     ];
   },
   // ESLint en build: el adapter de App Hosting ejecuta `next build`; la deuda de lint no debe bloquear el deploy.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "export:users-excel": "node scripts/export-firestore-users-to-xlsx.js",
     "script:send-reset-link": "node scripts/send-password-reset-link.js",
     "bounce:send": "node scripts/send-email-bounce.js",
-    "deploy:functions": "node scripts/deploy-functions.js"
+    "deploy:functions": "node scripts/deploy-functions.js",
+    "test": "npx tsx --tsconfig tsconfig.json --test src/lib/*.test.ts src/lib/public-api/*.test.ts",
+    "test:public-api": "npx tsx --tsconfig tsconfig.json --test src/lib/public-api/public-api.test.ts",
+    "api-key:create": "npx tsx scripts/create-api-key.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.13.0",

--- a/public/openapi/v1.yaml
+++ b/public/openapi/v1.yaml
@@ -1,0 +1,530 @@
+openapi: 3.0.3
+info:
+  title: Notificas Public API
+  version: 1.0.0
+  description: |
+    API REST v1 de notificaciones digitales certificadas y trazables.
+
+    Autenticación: `Authorization: Bearer ntf_live_…` o `ntf_test_…`.
+
+    Idempotencia: header `Idempotency-Key`.
+
+    Rate limits por API Key. 429 incluye `Retry-After`.
+
+    La constancia de envío documenta qué se envió, a quién y cuándo, con huellas SHA-256
+    y eventos de proveedor (Meta / transporte de correo). No es firma digital, documento
+    público, certificación notarial ni carta documento.
+  contact:
+    name: Notificas
+    url: https://notificas.com.ar
+servers:
+  - url: https://notificas.com.ar
+    description: Producción
+  - url: http://localhost:9006
+    description: Desarrollo
+tags:
+  - name: Notifications
+  - name: Batches
+  - name: Webhooks
+  - name: Account
+security:
+  - BearerAuth: []
+paths:
+  /api/v1/me:
+    get:
+      tags: [Account]
+      summary: Cuenta asociada a la API Key
+      operationId: getAccount
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  account:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      name: { type: string }
+                      environment: { type: string, enum: [live, test] }
+                      test_mode: { type: boolean }
+                      scopes:
+                        type: array
+                        items: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /api/v1/notifications:
+    get:
+      tags: [Notifications]
+      summary: Listar notificaciones
+      operationId: listNotifications
+      parameters:
+        - in: query
+          name: status
+          schema: { $ref: "#/components/schemas/NotificationStatus" }
+        - in: query
+          name: channel
+          schema: { type: string, enum: [whatsapp, email] }
+        - in: query
+          name: reference
+          schema: { type: string }
+        - in: query
+          name: created_from
+          schema: { type: string, format: date-time }
+        - in: query
+          name: created_to
+          schema: { type: string, format: date-time }
+        - in: query
+          name: recipient
+          schema: { type: string }
+          description: Email o teléfono a buscar
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+        - in: query
+          name: cursor
+          schema: { type: string }
+      responses:
+        "200":
+          description: Página
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "#/components/schemas/Notification" }
+                  has_more: { type: boolean }
+                  cursor: { type: string, nullable: true }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [Notifications]
+      summary: Crear una notificación certificada
+      operationId: sendCertifiedNotification
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateNotificationRequest" }
+            example:
+              channel: whatsapp
+              recipient:
+                name: Juan Pérez
+                phone: "+5493364123456"
+                email: juan@email.com
+                document: "20123456789"
+              template: notificacion_deuda_180_dias
+              variables:
+                nombre: Juan Pérez
+                dni: "20123456"
+                fecha: "27/08/2026"
+                monto: "125000"
+                cuotas: "4"
+              reference: CLIENTE-12345
+              metadata:
+                crm_id: "78482"
+                account_id: ABC123
+      responses:
+        "201":
+          description: Creada
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/NotificationCreated" }
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Error"
+        "422":
+          $ref: "#/components/responses/Error"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /api/v1/notifications/{notification_id}:
+    get:
+      tags: [Notifications]
+      summary: Consultar una notificación
+      operationId: getNotification
+      parameters:
+        - in: path
+          name: notification_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Notification" }
+        "404":
+          $ref: "#/components/responses/Error"
+  /api/v1/notifications/{notification_id}/certificate:
+    get:
+      tags: [Notifications]
+      summary: Constancia de envío (URL firmada temporal)
+      operationId: getNotificationCertificate
+      parameters:
+        - in: path
+          name: notification_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: ready o processing
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Certificate" }
+  /api/v1/batches:
+    post:
+      tags: [Batches]
+      summary: Crear un envío masivo asíncrono
+      operationId: createBatch
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateBatchRequest" }
+      responses:
+        "201":
+          description: Lote encolado
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BatchCreated" }
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /api/v1/batches/{batch_id}:
+    get:
+      tags: [Batches]
+      summary: Consultar un lote
+      operationId: getBatch
+      parameters:
+        - in: path
+          name: batch_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Batch" }
+  /api/v1/webhook-endpoints:
+    get:
+      tags: [Webhooks]
+      summary: Listar endpoints
+      operationId: listWebhookEndpoints
+      responses:
+        "200":
+          description: OK
+    post:
+      tags: [Webhooks]
+      summary: Registrar un endpoint (el secret se muestra una sola vez)
+      operationId: createWebhookEndpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateWebhookEndpointRequest" }
+            example:
+              url: https://crm.example.com/hooks/notificas
+              events:
+                - notification.delivered
+                - notification.read
+                - notification.failed
+                - notification.certificate_ready
+                - batch.completed
+      responses:
+        "201":
+          description: Creado
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/WebhookEndpointCreated" }
+  /api/v1/webhook-endpoints/{endpoint_id}:
+    get:
+      tags: [Webhooks]
+      operationId: getWebhookEndpoint
+      parameters:
+        - in: path
+          name: endpoint_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+    patch:
+      tags: [Webhooks]
+      operationId: updateWebhookEndpoint
+      parameters:
+        - in: path
+          name: endpoint_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+    delete:
+      tags: [Webhooks]
+      summary: Desactivar
+      operationId: disableWebhookEndpoint
+      parameters:
+        - in: path
+          name: endpoint_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Desactivado
+webhooks:
+  notificationEvent:
+    post:
+      tags: [Webhooks]
+      summary: Evento saliente firmado
+      description: |
+        Verificar HMAC-SHA256:
+
+        `signed_payload = notificas-id + "." + notificas-timestamp + "." + rawBody`
+
+        `notificas-signature` = `v1=<hex>`.
+
+        Rechazar si el timestamp difiere más de 300 segundos (anti-replay).
+        Los reintentos reutilizan el mismo `id` de evento.
+      parameters:
+        - in: header
+          name: notificas-id
+          required: true
+          schema: { type: string }
+        - in: header
+          name: notificas-timestamp
+          required: true
+          schema: { type: string }
+        - in: header
+          name: notificas-signature
+          required: true
+          schema: { type: string, example: "v1=…" }
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/WebhookEvent" }
+            example:
+              id: evt_01J00000000000000000000000
+              type: notification.delivered
+              created_at: "2026-08-27T13:15:00Z"
+              data:
+                notification_id: ntf_01J00000000000000000000000
+                reference: CLIENTE-12345
+                status: delivered
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: ntf_live_… | ntf_test_…
+  parameters:
+    IdempotencyKey:
+      in: header
+      name: Idempotency-Key
+      required: false
+      schema: { type: string, maxLength: 256 }
+      example: cobranza-982734
+  schemas:
+    NotificationStatus:
+      type: string
+      enum: [queued, processing, sent, delivered, read, failed]
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [type, code, message, request_id]
+          properties:
+            type:
+              type: string
+              enum:
+                - authentication_error
+                - authorization_error
+                - validation_error
+                - not_found
+                - conflict
+                - rate_limit_error
+                - idempotency_error
+                - api_error
+            code: { type: string }
+            message: { type: string }
+            request_id: { type: string }
+            param: { type: string }
+    CreateNotificationRequest:
+      type: object
+      additionalProperties: false
+      required: [channel, recipient]
+      properties:
+        channel: { type: string, enum: [whatsapp, email] }
+        recipient:
+          type: object
+          additionalProperties: false
+          properties:
+            name: { type: string }
+            phone: { type: string, example: "+5493364123456" }
+            email: { type: string, format: email }
+            document: { type: string }
+        template: { type: string }
+        variables:
+          type: object
+          additionalProperties: { type: string }
+        subject: { type: string }
+        body: { type: string }
+        reference: { type: string }
+        metadata:
+          type: object
+          additionalProperties: true
+    NotificationCreated:
+      type: object
+      properties:
+        id: { type: string, example: ntf_01J00000000000000000000000 }
+        status: { $ref: "#/components/schemas/NotificationStatus" }
+        channel: { type: string }
+        recipient:
+          type: object
+          properties:
+            phone: { type: string, example: "+5493364******" }
+            email: { type: string }
+        reference: { type: string }
+        created_at: { type: string, format: date-time }
+        test_mode: { type: boolean }
+    Notification:
+      allOf:
+        - $ref: "#/components/schemas/NotificationCreated"
+        - type: object
+          properties:
+            sent_at: { type: string, format: date-time, nullable: true }
+            delivered_at: { type: string, format: date-time, nullable: true }
+            read_at: { type: string, format: date-time, nullable: true }
+            failed_at: { type: string, format: date-time, nullable: true }
+            certificate_status: { type: string, enum: [processing, ready, sandbox, unavailable] }
+    Certificate:
+      type: object
+      properties:
+        status: { type: string, enum: [processing, ready] }
+        kind: { type: string, example: constancia_envio }
+        download_url: { type: string, format: uri }
+        expires_at: { type: string, format: date-time }
+        test_mode: { type: boolean }
+        message: { type: string }
+    CreateBatchRequest:
+      type: object
+      additionalProperties: false
+      required: [channel, recipients]
+      properties:
+        channel: { type: string, enum: [whatsapp, email] }
+        template: { type: string }
+        subject: { type: string }
+        body: { type: string }
+        reference: { type: string }
+        metadata: { type: object }
+        recipients:
+          type: array
+          maxItems: 5000
+          items:
+            type: object
+            properties:
+              name: { type: string }
+              phone: { type: string }
+              email: { type: string }
+              document: { type: string }
+              variables: { type: object }
+    BatchCreated:
+      type: object
+      properties:
+        id: { type: string, example: batch_01J00000000000000000000000 }
+        status: { type: string, example: queued }
+        total: { type: integer }
+        channel: { type: string }
+        test_mode: { type: boolean }
+    Batch:
+      type: object
+      properties:
+        id: { type: string }
+        status: { type: string, enum: [queued, processing, completed, paused, cancelled, failed] }
+        total: { type: integer }
+        queued: { type: integer }
+        sent: { type: integer }
+        delivered: { type: integer }
+        read: { type: integer }
+        failed: { type: integer }
+        channel: { type: string, nullable: true }
+        created_at: { type: string, format: date-time, nullable: true }
+        test_mode: { type: boolean }
+    CreateWebhookEndpointRequest:
+      type: object
+      required: [url, events]
+      properties:
+        url: { type: string, format: uri }
+        events:
+          type: array
+          items:
+            type: string
+            enum:
+              - notification.queued
+              - notification.sent
+              - notification.delivered
+              - notification.read
+              - notification.failed
+              - notification.certificate_ready
+              - batch.completed
+        description: { type: string }
+    WebhookEndpointCreated:
+      type: object
+      properties:
+        id: { type: string }
+        url: { type: string }
+        events:
+          type: array
+          items: { type: string }
+        status: { type: string }
+        secret: { type: string, example: whsec_… }
+        secret_prefix: { type: string }
+    WebhookEvent:
+      type: object
+      properties:
+        id: { type: string }
+        type: { type: string }
+        created_at: { type: string, format: date-time }
+        data:
+          type: object
+          additionalProperties: true
+  responses:
+    Error:
+      description: Error normalizado
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example:
+            error:
+              type: validation_error
+              code: invalid_phone
+              message: The recipient phone number is invalid.
+              request_id: req_01J00000000000000000000000
+              param: recipient.phone
+    Unauthorized:
+      description: API Key inválida o revocada
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    RateLimited:
+      description: Rate limit
+      headers:
+        Retry-After:
+          schema: { type: integer }
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }

--- a/public/openapi/v1.yaml
+++ b/public/openapi/v1.yaml
@@ -14,6 +14,9 @@ info:
     La constancia de envío documenta qué se envió, a quién y cuándo, con huellas SHA-256
     y eventos de proveedor (Meta / transporte de correo). No es firma digital, documento
     público, certificación notarial ni carta documento.
+
+    SDK web (widget + cliente JS, sin exponer `ntf_live_` en el navegador):
+    `https://notificas.com.ar/sdk/v1/notificas.js` — guía en `/docs/api/embed`.
   contact:
     name: Notificas
     url: https://notificas.com.ar

--- a/public/sdk/v1/notificas.d.ts
+++ b/public/sdk/v1/notificas.d.ts
@@ -1,0 +1,67 @@
+export interface NotificasRecipient {
+  name?: string;
+  phone?: string;
+  email?: string;
+  document?: string;
+}
+
+export interface SendCertifiedNotificationInput {
+  channel: "whatsapp" | "email";
+  recipient: NotificasRecipient;
+  template?: string;
+  variables?: Record<string, string>;
+  subject?: string;
+  body?: string;
+  reference?: string;
+  metadata?: Record<string, string | number | boolean>;
+  idempotencyKey?: string;
+}
+
+export interface NotificasClientOptions {
+  /** Backend propio que reenvía a Notificas. Recomendado en sitios públicos. */
+  proxyUrl?: string;
+  apiKey?: string;
+  allowBrowserKey?: boolean;
+  baseUrl?: string;
+  requestId?: string;
+  /**
+   * Si true, proxyUrl se concatena con el path completo `/api/v1/…`.
+   * Por defecto el proxy reemplaza `https://notificas.com.ar/api/v1`
+   * (`/api/notificas` + `/notifications`).
+   */
+  proxyMapsFullPath?: boolean;
+}
+
+export interface NotificasClient {
+  version: string;
+  sendCertifiedNotification(input: SendCertifiedNotificationInput): Promise<unknown>;
+  getNotification(id: string): Promise<unknown>;
+  getCertificate(id: string): Promise<unknown>;
+  listNotifications(query?: Record<string, string | number>): Promise<unknown>;
+  me(): Promise<unknown>;
+}
+
+export interface NotificasEmbedOptions extends NotificasClientOptions {
+  channel?: "whatsapp" | "email";
+  template?: string;
+  title?: string;
+  subtitle?: string;
+  variables?: Record<string, string>;
+  metadata?: Record<string, string | number | boolean>;
+  hideTemplate?: boolean;
+  showAllFields?: boolean;
+  demo?: boolean;
+  buttonLabel?: string;
+  onSent?: (result: unknown) => void;
+  onError?: (error: unknown) => void;
+}
+
+export interface NotificasGlobal {
+  version: string;
+  create(options: NotificasClientOptions): NotificasClient;
+  embed(target: string | Element, options?: NotificasEmbedOptions): { destroy(): void; client: NotificasClient | null };
+  autoEmbed(): void;
+}
+
+declare const Notificas: NotificasGlobal;
+export default Notificas;

--- a/public/sdk/v1/notificas.js
+++ b/public/sdk/v1/notificas.js
@@ -1,0 +1,415 @@
+/**
+ * Notificas Web SDK v1 — instrumento para insertar la API en sitios.
+ *
+ * <script src="https://notificas.com.ar/sdk/v1/notificas.js"></script>
+ *
+ * Uso recomendado en webs públicas: proxyUrl (la API Key queda en tu servidor).
+ * No pongas ntf_live_… en HTML público.
+ */
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  if (typeof root === "object" && root) {
+    root.Notificas = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  var VERSION = "1.0.0";
+  var DEFAULT_BASE = "https://notificas.com.ar";
+  var STYLE_ID = "notificas-embed-css";
+
+  function isBrowser() {
+    return typeof window !== "undefined" && typeof document !== "undefined";
+  }
+
+  function trimSlash(url) {
+    return String(url || "").replace(/\/+$/, "");
+  }
+
+  function randomIdempotencyKey() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+    return "web_" + Date.now().toString(36) + "_" + Math.random().toString(36).slice(2, 10);
+  }
+
+  function isLiveKey(key) {
+    return String(key || "").trim().indexOf("ntf_live_") === 0;
+  }
+
+  function assertBrowserKeySafe(opts) {
+    var apiKey = opts && opts.apiKey;
+    var proxyUrl = opts && opts.proxyUrl;
+    var allow = opts && opts.allowBrowserKey === true;
+    if (proxyUrl) return;
+    if (!apiKey) {
+      throw new Error("Notificas: definí proxyUrl (recomendado) o apiKey.");
+    }
+    if (isBrowser() && isLiveKey(apiKey) && !allow) {
+      throw new Error(
+        "Notificas: no uses una clave ntf_live_ en el navegador. Configurá proxyUrl hacia tu backend."
+      );
+    }
+  }
+
+  function requestHeaders(opts, extra) {
+    var headers = { "Content-Type": "application/json", Accept: "application/json" };
+    if (opts.apiKey && !opts.proxyUrl) headers.Authorization = "Bearer " + opts.apiKey;
+    if (opts.requestId) headers["X-Request-Id"] = opts.requestId;
+    if (extra) {
+      for (var k in extra) if (Object.prototype.hasOwnProperty.call(extra, k) && extra[k]) headers[k] = extra[k];
+    }
+    return headers;
+  }
+
+  function stripApiV1(path) {
+    var p = String(path || "");
+    if (p.indexOf("/api/v1/") === 0) return p.slice("/api/v1".length);
+    if (p === "/api/v1") return "";
+    return p;
+  }
+
+  function resolveUrl(opts, path) {
+    if (opts.proxyUrl) {
+      var proxy = trimSlash(opts.proxyUrl);
+      if (opts.proxyMapsFullPath) return proxy + path;
+      return proxy + stripApiV1(path);
+    }
+    return trimSlash(opts.baseUrl || DEFAULT_BASE) + path;
+  }
+
+  function parseError(status, body, requestId) {
+    var errBody = body && body.error ? body.error : {};
+    var error = new Error(errBody.message || "HTTP " + status);
+    error.name = "NotificasApiError";
+    error.status = status;
+    error.type = errBody.type || "api_error";
+    error.code = errBody.code || "http_error";
+    error.requestId = errBody.request_id || requestId || null;
+    error.param = errBody.param;
+    return error;
+  }
+
+  function createClient(options) {
+    var opts = options || {};
+    assertBrowserKeySafe(opts);
+    if (!opts.baseUrl) opts.baseUrl = DEFAULT_BASE;
+
+    function request(method, path, body, extraHeaders) {
+      var url = resolveUrl(opts, path);
+      var init = { method: method, headers: requestHeaders(opts, extraHeaders) };
+      if (body !== undefined && body !== null && method !== "GET") init.body = JSON.stringify(body);
+      return fetch(url, init).then(function (res) {
+        return res.json().catch(function () { return {}; }).then(function (json) {
+          var requestId =
+            res.headers && typeof res.headers.get === "function"
+              ? res.headers.get("X-Request-Id")
+              : null;
+          if (!res.ok) throw parseError(res.status, json, requestId);
+          return json;
+        });
+      });
+    }
+
+    return {
+      version: VERSION,
+      sendCertifiedNotification: function (input) {
+        var payload = input || {};
+        var idem = payload.idempotencyKey || randomIdempotencyKey();
+        var body = {
+          channel: payload.channel,
+          recipient: payload.recipient,
+          template: payload.template,
+          variables: payload.variables,
+          subject: payload.subject,
+          body: payload.body,
+          reference: payload.reference,
+          metadata: payload.metadata,
+        };
+        return request("POST", "/api/v1/notifications", body, { "Idempotency-Key": idem });
+      },
+      getNotification: function (id) {
+        return request("GET", "/api/v1/notifications/" + encodeURIComponent(id));
+      },
+      getCertificate: function (id) {
+        return request("GET", "/api/v1/notifications/" + encodeURIComponent(id) + "/certificate");
+      },
+      listNotifications: function (query) {
+        var q = query || {};
+        var params = new URLSearchParams();
+        Object.keys(q).forEach(function (k) {
+          if (q[k] != null && q[k] !== "") params.set(k, String(q[k]));
+        });
+        var qs = params.toString();
+        return request("GET", "/api/v1/notifications" + (qs ? "?" + qs : ""));
+      },
+      me: function () {
+        return request("GET", "/api/v1/me");
+      },
+    };
+  }
+
+  function css() {
+    return [
+      ".ntf-embed{all:initial;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;display:block;max-width:440px;}",
+      ".ntf-embed *{box-sizing:border-box;font-family:inherit;}",
+      ".ntf-card{border:1px solid #d7e0e2;border-radius:12px;background:#fff;padding:20px 20px 16px;box-shadow:0 8px 24px rgba(15,23,42,.06);}",
+      ".ntf-brand{display:flex;align-items:center;gap:8px;margin-bottom:4px;}",
+      ".ntf-mark{width:28px;height:28px;border-radius:8px;background:#0D9488;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;}",
+      ".ntf-title{font-size:16px;font-weight:700;margin:0;}",
+      ".ntf-sub{font-size:12px;color:#64748b;margin:0 0 14px;line-height:1.45;}",
+      ".ntf-row{display:flex;gap:8px;}",
+      ".ntf-field{display:flex;flex-direction:column;gap:4px;margin-bottom:10px;flex:1;}",
+      ".ntf-field label{font-size:12px;font-weight:600;color:#334155;}",
+      ".ntf-field input,.ntf-field select,.ntf-field textarea{width:100%;border:1px solid #cbd5e1;border-radius:8px;padding:8px 10px;font-size:14px;background:#fff;color:#0f172a;}",
+      ".ntf-field textarea{min-height:64px;resize:vertical;}",
+      ".ntf-field input:focus,.ntf-field select:focus,.ntf-field textarea:focus{outline:2px solid #99f6e4;border-color:#0D9488;}",
+      ".ntf-btn{width:100%;border:0;border-radius:8px;background:#0D9488;color:#fff;font-weight:700;font-size:14px;padding:10px 12px;cursor:pointer;}",
+      ".ntf-btn:disabled{opacity:.6;cursor:not-allowed;}",
+      ".ntf-btn:hover:not(:disabled){background:#0f766e;}",
+      ".ntf-msg{margin-top:10px;font-size:13px;line-height:1.4;border-radius:8px;padding:8px 10px;}",
+      ".ntf-ok{background:#ecfdf5;color:#065f46;}",
+      ".ntf-err{background:#fef2f2;color:#991b1b;}",
+      ".ntf-foot{margin-top:10px;font-size:11px;color:#94a3b8;}",
+      ".ntf-foot a{color:#0D9488;text-decoration:none;}",
+    ].join("");
+  }
+
+  function ensureStyle() {
+    if (!isBrowser() || document.getElementById(STYLE_ID)) return;
+    var el = document.createElement("style");
+    el.id = STYLE_ID;
+    el.textContent = css();
+    document.head.appendChild(el);
+  }
+
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        if (k === "className") node.className = attrs[k];
+        else if (k === "text") node.textContent = attrs[k];
+        else if (k.indexOf("on") === 0 && typeof attrs[k] === "function") node.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
+        else if (attrs[k] != null) node.setAttribute(k, String(attrs[k]));
+      });
+    }
+    (children || []).forEach(function (c) {
+      if (c) node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    });
+    return node;
+  }
+
+  function field(label, input) {
+    return el("div", { className: "ntf-field" }, [el("label", { text: label }), input]);
+  }
+
+  function parseVariables(raw) {
+    var t = String(raw || "").trim();
+    if (!t) return {};
+    if (t.charAt(0) === "{") {
+      var json = JSON.parse(t);
+      if (!json || typeof json !== "object" || Array.isArray(json)) throw new Error("variables inválidas");
+      return json;
+    }
+    var out = {};
+    t.split(/[\n,]/).forEach(function (line) {
+      var i = line.indexOf("=");
+      if (i < 1) return;
+      out[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+    });
+    return out;
+  }
+
+  function embed(target, options) {
+    if (!isBrowser()) throw new Error("Notificas.embed solo funciona en el navegador.");
+    ensureStyle();
+    var opts = options || {};
+    var mount = typeof target === "string" ? document.querySelector(target) : target;
+    if (!mount) throw new Error("Notificas.embed: no se encontró el contenedor.");
+
+    var client = null;
+    if (!opts.demo) client = createClient(opts);
+
+    mount.innerHTML = "";
+    var root = el("div", { className: "ntf-embed" });
+    var channel = el("select", null, [
+      el("option", { value: "whatsapp", text: "WhatsApp" }),
+      el("option", { value: "email", text: "Email" }),
+    ]);
+    channel.value = opts.channel === "email" ? "email" : "whatsapp";
+    var name = el("input", { type: "text", autocomplete: "name", maxlength: "120" });
+    var phone = el("input", { type: "tel", autocomplete: "tel", placeholder: "+54911…" });
+    var email = el("input", { type: "email", autocomplete: "email", placeholder: "correo@dominio.com" });
+    var documentId = el("input", { type: "text", maxlength: "20", placeholder: "DNI / CUIT" });
+    var template = el("input", { type: "text", maxlength: "128", placeholder: "notificacion_deuda_180_dias" });
+    if (opts.template) template.value = opts.template;
+    var reference = el("input", { type: "text", maxlength: "128", placeholder: "CLIENTE-12345" });
+    var variables = el("textarea", {
+      placeholder: "nombre=Juan Pérez\ndni=20123456\nmonto=125000",
+    });
+    if (opts.variables && typeof opts.variables === "object") {
+      variables.value = Object.keys(opts.variables)
+        .map(function (k) { return k + "=" + opts.variables[k]; })
+        .join("\n");
+    }
+    var subject = el("input", { type: "text", maxlength: "300", placeholder: "Asunto del correo" });
+    var body = el("textarea", { placeholder: "Texto del mensaje (email)" });
+    var status = el("div");
+    var buttonLabel = opts.buttonLabel || "Enviar notificación";
+    var btn = el("button", { className: "ntf-btn", type: "button", text: buttonLabel });
+
+    function setMsg(ok, text) {
+      status.className = "ntf-msg " + (ok ? "ntf-ok" : "ntf-err");
+      status.textContent = text;
+    }
+
+    function syncChannel() {
+      var wa = channel.value === "whatsapp";
+      phone.parentElement.style.display = wa || opts.showAllFields ? "" : "none";
+      email.parentElement.style.display = !wa || opts.showAllFields ? "" : "none";
+      subject.parentElement.style.display = wa ? "none" : "";
+      body.parentElement.style.display = wa ? "none" : "";
+      template.parentElement.style.display = opts.hideTemplate ? "none" : "";
+    }
+    channel.addEventListener("change", syncChannel);
+
+    btn.addEventListener("click", function () {
+      status.textContent = "";
+      status.className = "";
+      var vars;
+      try {
+        vars = parseVariables(variables.value);
+      } catch (e) {
+        setMsg(false, "Revisá las variables (JSON o clave=valor).");
+        return;
+      }
+      var payload = {
+        channel: channel.value,
+        recipient: {
+          name: name.value.trim() || undefined,
+          phone: phone.value.trim() || undefined,
+          email: email.value.trim() || undefined,
+          document: documentId.value.trim() || undefined,
+        },
+        template: template.value.trim() || undefined,
+        variables: vars,
+        reference: reference.value.trim() || undefined,
+        subject: subject.value.trim() || undefined,
+        body: body.value.trim() || undefined,
+        metadata: opts.metadata,
+      };
+      if (opts.demo) {
+        setMsg(true, "Modo demostración: no se envió nada. En producción usá proxyUrl o una clave de test.");
+        if (typeof opts.onSent === "function") opts.onSent({ id: "ntf_demo", status: "queued", test_mode: true, demo: true });
+        return;
+      }
+      btn.disabled = true;
+      btn.textContent = "Enviando…";
+      client
+        .sendCertifiedNotification(payload)
+        .then(function (res) {
+          var id = res && res.id ? res.id : "";
+          var st = res && res.status ? res.status : "queued";
+          setMsg(true, "Enviada. ID " + id + " · estado " + st + ". Queda constancia técnica de qué se envió, a quién y cuándo.");
+          if (typeof opts.onSent === "function") opts.onSent(res);
+        })
+        .catch(function (err) {
+          setMsg(false, (err && err.message) || "No se pudo enviar.");
+          if (typeof opts.onError === "function") opts.onError(err);
+        })
+        .then(function () {
+          btn.disabled = false;
+          btn.textContent = buttonLabel;
+        });
+    });
+
+    root.appendChild(
+      el("div", { className: "ntf-card" }, [
+        el("div", { className: "ntf-brand" }, [
+          el("div", { className: "ntf-mark", text: "N" }),
+          el("p", { className: "ntf-title", text: opts.title || "Notificación certificada" }),
+        ]),
+        el("p", {
+          className: "ntf-sub",
+          text:
+            opts.subtitle ||
+            "Envía un mensaje y deja constancia de qué salió, a quién y cuándo. No reemplaza una carta documento si la norma pide esa forma.",
+        }),
+        field("Canal", channel),
+        field("Nombre", name),
+        field("Teléfono (WhatsApp)", phone),
+        field("Email", email),
+        field("Documento", documentId),
+        field("Plantilla", template),
+        field("Referencia", reference),
+        field("Variables (clave=valor)", variables),
+        field("Asunto", subject),
+        field("Cuerpo", body),
+        btn,
+        status,
+        el("p", { className: "ntf-foot" }, [
+          document.createTextNode("Instrumento "),
+          el("a", { href: "https://notificas.com.ar/docs/api/embed", text: "Notificas API" }),
+        ]),
+      ])
+    );
+    mount.appendChild(root);
+    syncChannel();
+    return {
+      destroy: function () {
+        mount.innerHTML = "";
+      },
+      client: client,
+    };
+  }
+
+  function autoEmbed() {
+    if (!isBrowser()) return;
+    var nodes = document.querySelectorAll("[data-notificas-embed]");
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      if (node.getAttribute("data-notificas-ready") === "1") continue;
+      var varsRaw = node.getAttribute("data-variables");
+      var variables;
+      try {
+        variables = varsRaw ? JSON.parse(varsRaw) : undefined;
+      } catch (e) {
+        variables = undefined;
+      }
+      embed(node, {
+        proxyUrl: node.getAttribute("data-proxy-url") || undefined,
+        apiKey: node.getAttribute("data-api-key") || undefined,
+        allowBrowserKey: node.getAttribute("data-allow-browser-key") === "true",
+        baseUrl: node.getAttribute("data-base-url") || undefined,
+        channel: node.getAttribute("data-channel") || undefined,
+        template: node.getAttribute("data-template") || undefined,
+        title: node.getAttribute("data-title") || undefined,
+        demo: node.getAttribute("data-demo") === "true",
+        hideTemplate: node.getAttribute("data-hide-template") === "true",
+        buttonLabel: node.getAttribute("data-button-label") || undefined,
+        variables: variables,
+      });
+      node.setAttribute("data-notificas-ready", "1");
+    }
+  }
+
+  if (isBrowser()) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", autoEmbed);
+    } else {
+      autoEmbed();
+    }
+  }
+
+  return {
+    version: VERSION,
+    create: createClient,
+    embed: embed,
+    autoEmbed: autoEmbed,
+    _assertBrowserKeySafe: assertBrowserKeySafe,
+    _parseVariables: parseVariables,
+    _resolveUrl: resolveUrl,
+    _isLiveKey: isLiveKey,
+  };
+});

--- a/scripts/create-api-key.ts
+++ b/scripts/create-api-key.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Genera o revoca una API Key de la API pública v1.
+ *
+ *   npx tsx scripts/create-api-key.ts --orgId ORG_ID --name "CRM" --env live
+ *   npx tsx scripts/create-api-key.ts --revoke key_01J… --orgId ORG_ID
+ *
+ * Requiere .env.local con credenciales Admin (igual que el resto de scripts).
+ */
+
+import path from "path";
+import { config } from "dotenv";
+
+config({ path: path.join(process.cwd(), ".env.local") });
+
+async function main() {
+  const args = process.argv.slice(2);
+  const get = (flag: string) => {
+    const i = args.indexOf(flag);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const { createApiKey, revokeApiKey } = await import("../src/lib/public-api/api-keys");
+
+  const revokeId = get("--revoke");
+  const orgId = get("--orgId");
+  if (revokeId) {
+    if (!orgId) {
+      console.error("--orgId es requerido para revocar");
+      process.exit(1);
+    }
+    await revokeApiKey({ keyId: revokeId, orgId });
+    console.log("Revocada", revokeId);
+    return;
+  }
+
+  if (!orgId) {
+    console.error("Uso: npx tsx scripts/create-api-key.ts --orgId ORG_ID --name NAME --env live|test");
+    process.exit(1);
+  }
+  const created = await createApiKey({
+    orgId,
+    name: get("--name") || "default",
+    environment: get("--env") === "test" ? "test" : "live",
+    createdBy: "script",
+  });
+  console.log("id:", created.record.id);
+  console.log("prefix:", created.record.prefix);
+  console.log("secret (copiá ahora, no se vuelve a mostrar):");
+  console.log(created.secret);
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/src/app/admin/api-keys/page.tsx
+++ b/src/app/admin/api-keys/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { KeyRound, Loader2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+
+type OrgRow = { id: string; nombre?: string; adminUserEmail?: string };
+type KeyRow = {
+  id: string;
+  name: string;
+  prefix: string;
+  environment: string;
+  status: string;
+  createdAt: string | null;
+  lastUsedAt: string | null;
+};
+
+export default function AdminApiKeysPage() {
+  const { toast } = useToast();
+  const [orgs, setOrgs] = useState<OrgRow[]>([]);
+  const [orgId, setOrgId] = useState("");
+  const [keys, setKeys] = useState<KeyRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [name, setName] = useState("Producción");
+  const [environment, setEnvironment] = useState<"live" | "test">("live");
+  const [revealed, setRevealed] = useState<string | null>(null);
+
+  async function loadOrgs() {
+    const res = await fetch("/api/admin/organizations", { credentials: "include" });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || "Error");
+    setOrgs(data.organizations || []);
+  }
+
+  async function loadKeys(id: string) {
+    if (!id) {
+      setKeys([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/api-keys?orgId=${encodeURIComponent(id)}`, { credentials: "include" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Error");
+      setKeys(data.keys || []);
+    } catch (e: unknown) {
+      toast({ title: "No se pudieron cargar las claves", description: e instanceof Error ? e.message : "", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadOrgs().catch((e) =>
+      toast({ title: "Error al listar empresas", description: e instanceof Error ? e.message : "", variant: "destructive" })
+    );
+  }, []);
+
+  useEffect(() => {
+    void loadKeys(orgId);
+  }, [orgId]);
+
+  async function createKey() {
+    if (!orgId) {
+      toast({ title: "Elegí una empresa", variant: "destructive" });
+      return;
+    }
+    setSaving(true);
+    setRevealed(null);
+    try {
+      const res = await fetch("/api/admin/api-keys", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgId, name, environment }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Error");
+      setRevealed(data.secret);
+      toast({ title: "API Key creada", description: "Copiá el secret ahora. No se vuelve a mostrar." });
+      await loadKeys(orgId);
+    } catch (e: unknown) {
+      toast({ title: "No se pudo crear la clave", description: e instanceof Error ? e.message : "", variant: "destructive" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function revoke(keyId: string) {
+    if (!confirm("¿Revocar esta API Key? Las integraciones dejarán de autenticarse.")) return;
+    const res = await fetch(`/api/admin/api-keys?keyId=${encodeURIComponent(keyId)}&orgId=${encodeURIComponent(orgId)}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      toast({ title: "No se pudo revocar", description: data.error || "", variant: "destructive" });
+      return;
+    }
+    toast({ title: "Clave revocada" });
+    await loadKeys(orgId);
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <KeyRound className="h-5 w-5" />
+            API Keys de empresas
+          </CardTitle>
+          <CardDescription>
+            Generá o revocá claves para la API pública v1. El secret completo se muestra una sola vez.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>Empresa</Label>
+            <Select value={orgId} onValueChange={setOrgId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Seleccionar organización" />
+              </SelectTrigger>
+              <SelectContent>
+                {orgs.map((o) => (
+                  <SelectItem key={o.id} value={o.id}>
+                    {o.nombre || o.id} {o.adminUserEmail ? `(${o.adminUserEmail})` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label>Nombre</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} maxLength={80} />
+            </div>
+            <div className="space-y-2">
+              <Label>Ambiente</Label>
+              <Select value={environment} onValueChange={(v) => setEnvironment(v as "live" | "test")}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="live">live (ntf_live_)</SelectItem>
+                  <SelectItem value="test">test / sandbox (ntf_test_)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-end">
+              <Button onClick={createKey} disabled={saving || !orgId}>
+                {saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+                Generar clave
+              </Button>
+            </div>
+          </div>
+          {revealed ? (
+            <div className="rounded-md border bg-muted/40 p-3 text-sm">
+              <p className="font-medium mb-1">Secret (copiá ahora)</p>
+              <code className="break-all">{revealed}</code>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle>Claves</CardTitle>
+            <CardDescription>Nunca se guarda el secret en texto plano. Solo el prefijo y un hash.</CardDescription>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => loadKeys(orgId)} disabled={loading || !orgId}>
+            <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+            Actualizar
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nombre</TableHead>
+                  <TableHead>Prefijo</TableHead>
+                  <TableHead>Ambiente</TableHead>
+                  <TableHead>Estado</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loading ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-muted-foreground">Cargando…</TableCell>
+                  </TableRow>
+                ) : keys.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-muted-foreground">
+                      {orgId ? "No hay claves para esta empresa." : "Elegí una empresa."}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  keys.map((k) => (
+                    <TableRow key={k.id}>
+                      <TableCell>{k.name}</TableCell>
+                      <TableCell className="font-mono text-xs">{k.prefix}…</TableCell>
+                      <TableCell>{k.environment}</TableCell>
+                      <TableCell>{k.status}</TableCell>
+                      <TableCell className="text-right">
+                        {k.status === "active" ? (
+                          <Button variant="destructive" size="sm" onClick={() => revoke(k.id)}>
+                            Revocar
+                          </Button>
+                        ) : null}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/api-keys/page.tsx
+++ b/src/app/admin/api-keys/page.tsx
@@ -124,6 +124,11 @@ export default function AdminApiKeysPage() {
           </CardTitle>
           <CardDescription>
             Generá o revocá claves para la API pública v1. El secret completo se muestra una sola vez.
+            Para pegar un widget en un sitio usá{" "}
+            <a href="/docs/api/embed" className="underline">
+              /docs/api/embed
+            </a>{" "}
+            (nunca pongas <code>ntf_live_</code> en el navegador).
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/app/api/admin/api-keys/route.ts
+++ b/src/app/api/admin/api-keys/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { assertAdminSession } from "@/lib/assert-admin-session";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { createApiKey, listApiKeys, revokeApiKey } from "@/lib/public-api/api-keys";
+import { PUBLIC_API_SCOPES } from "@/lib/public-api/scopes";
+
+const createSchema = z.object({
+  orgId: z.string().min(1),
+  name: z.string().min(1).max(80),
+  environment: z.enum(["live", "test"]),
+  scopes: z.array(z.enum(PUBLIC_API_SCOPES)).optional(),
+});
+
+function serializeKey(row: Awaited<ReturnType<typeof listApiKeys>>[number]) {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    name: row.name,
+    prefix: row.prefix,
+    environment: row.environment,
+    scopes: row.scopes,
+    status: row.status,
+    createdAt: row.createdAt && typeof (row.createdAt as { toDate?: () => Date }).toDate === "function"
+      ? (row.createdAt as { toDate: () => Date }).toDate().toISOString()
+      : null,
+    lastUsedAt:
+      row.lastUsedAt && typeof (row.lastUsedAt as { toDate?: () => Date }).toDate === "function"
+        ? (row.lastUsedAt as { toDate: () => Date }).toDate().toISOString()
+        : null,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const denied = assertAdminSession(request);
+  if (denied) return denied;
+  const orgId = request.nextUrl.searchParams.get("orgId") || "";
+  if (!orgId) return NextResponse.json({ error: "orgId requerido" }, { status: 400 });
+  try {
+    const keys = await listApiKeys(orgId);
+    return NextResponse.json({ keys: keys.map(serializeKey) });
+  } catch (e) {
+    console.error("GET /api/admin/api-keys", e);
+    return NextResponse.json({ error: "Error al listar API keys" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const denied = assertAdminSession(request);
+  if (denied) return denied;
+  try {
+    const parsed = createSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    }
+    const orgSnap = await getAdminDb().collection("organizations").doc(parsed.data.orgId).get();
+    if (!orgSnap.exists) return NextResponse.json({ error: "Organización no encontrada" }, { status: 404 });
+
+    const created = await createApiKey({
+      orgId: parsed.data.orgId,
+      name: parsed.data.name,
+      environment: parsed.data.environment,
+      scopes: parsed.data.scopes,
+      createdBy: "admin",
+    });
+    return NextResponse.json({
+      key: serializeKey(created.record),
+      secret: created.secret,
+    });
+  } catch (e) {
+    console.error("POST /api/admin/api-keys", e);
+    return NextResponse.json({ error: "Error al crear API key" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const denied = assertAdminSession(request);
+  if (denied) return denied;
+  try {
+    const keyId = request.nextUrl.searchParams.get("keyId") || "";
+    const orgId = request.nextUrl.searchParams.get("orgId") || undefined;
+    if (!keyId) return NextResponse.json({ error: "keyId requerido" }, { status: 400 });
+    await revokeApiKey({ keyId, orgId });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    const status = typeof (e as { httpStatus?: number }).httpStatus === "number" ? (e as { httpStatus: number }).httpStatus : 500;
+    const message = e instanceof Error ? e.message : "Error al revocar";
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/campaigns/fanout/route.ts
+++ b/src/app/api/campaigns/fanout/route.ts
@@ -11,6 +11,7 @@ import { sealCampaignWhatsAppTemplate } from '@/lib/wa-template-seal';
 import { RECIPIENT_CHUNK_SIZE } from '@/lib/campaign-recipients';
 import { isSyntheticCampaignEmail, phoneDigits, presentRecipientValue, recipientValueText } from '@/lib/parse-campaign-csv';
 import type { RecipientEntry } from '@/lib/types';
+import { newNotificationId } from '@/lib/public-api/ids';
 
 // Destinatarios que procesa cada invocación del fanout (un archivo de Storage).
 const FANOUT_PAGE = RECIPIENT_CHUNK_SIZE;
@@ -326,6 +327,10 @@ async function processFanoutPage(
       toProcess.push(existing.id);
     } else {
       const ref = db.collection('campaign_messages').doc();
+      const publicApiId =
+        typeof campaign.publicApiBatchId === 'string' && campaign.publicApiBatchId
+          ? newNotificationId(campaign.publicApiTestMode === true)
+          : undefined;
       batchOps.set(ref, {
         campaignId,
         orgId: campaign.orgId,
@@ -344,6 +349,13 @@ async function processFanoutPage(
         sendTandaIndex: tandaIndex,
         integritySendBatchId: integrityBatchId,
         createdAt: FieldValue.serverTimestamp(),
+        ...(publicApiId
+          ? {
+              publicApiId,
+              apiSource: 'public_api',
+              apiBatchId: campaign.publicApiBatchId,
+            }
+          : {}),
       });
       toProcess.push(ref.id);
       batchCount += 1;

--- a/src/app/api/campaigns/worker/route.ts
+++ b/src/app/api/campaigns/worker/route.ts
@@ -25,6 +25,7 @@ import { waitCampaignSendGap } from '@/lib/campaign-send-pace';
 import { completeSimulatedSend, isCampaignSimulated } from '@/lib/campaign-simulate';
 import { presentRecipientValue, recipientValueText } from '@/lib/parse-campaign-csv';
 import type { CampaignAttachment, RecipientEntry } from '@/lib/types';
+import { registerPublicApiNotification, syncPublicApiNotificationFromMail } from '@/lib/public-api/status-sync';
 
 class WorkerRetryError extends Error {
   readonly retry = true;
@@ -251,6 +252,17 @@ async function processMessage(
           } : {}),
           ...(waOnly ? { waOnly: true } : {}),
           ...(isCampaignSimulated(campaign) ? { simulated: true } : {}),
+          ...(typeof campaign.publicApiBatchId === 'string' && campaign.publicApiBatchId
+            ? {
+                orgId,
+                publicApiId: typeof msg.publicApiId === 'string' ? msg.publicApiId : undefined,
+                apiSource: 'public_api',
+                apiBatchId: String(campaign.publicApiBatchId),
+                testMode: campaign.publicApiTestMode === true,
+                apiKeyId: typeof campaign.apiKeyId === 'string' ? campaign.apiKeyId : undefined,
+                apiReference: typeof campaign.apiReference === 'string' ? campaign.apiReference : undefined,
+              }
+            : {}),
         });
         await msgRef.update({
           mailId,
@@ -258,6 +270,24 @@ async function processMessage(
           mailClaimAt: FieldValue.delete(),
           estado: 'pendiente',
         });
+        if (typeof campaign.publicApiBatchId === 'string' && campaign.publicApiBatchId && mailId) {
+          const ntfId = typeof msg.publicApiId === 'string' ? msg.publicApiId : undefined;
+          if (ntfId) {
+            void registerPublicApiNotification({
+              id: ntfId,
+              orgId,
+              mailId,
+              channel: canal === 'email' ? 'email' : 'whatsapp',
+              batchId: String(campaign.publicApiBatchId),
+              testMode: campaign.publicApiTestMode === true,
+              apiKeyId: typeof campaign.apiKeyId === 'string' ? campaign.apiKeyId : undefined,
+              reference: typeof campaign.apiReference === 'string' ? campaign.apiReference : null,
+              recipientPhone: row.telefono,
+              recipientEmail: emailRaw,
+              recipientName: row.nombre,
+            }).catch(() => undefined);
+          }
+        }
       } catch (e) {
         await msgRef.update({
           mailClaimLock: FieldValue.delete(),
@@ -389,6 +419,7 @@ async function processMessage(
       phone: String(row.telefono || ''),
       contentHash,
     });
+    void syncPublicApiNotificationFromMail(mailId, 'failed').catch(() => undefined);
     return 'error';
   }
 
@@ -515,6 +546,7 @@ async function processMessage(
       console.log(`✅ Evento WA pendiente '${st}' procesado para wamid=${wamid}`);
     }
   }
+  void syncPublicApiNotificationFromMail(mailId, 'sent').catch(() => undefined);
   return 'sent';
 }
 

--- a/src/app/api/internal/public-api/send/route.ts
+++ b/src/app/api/internal/public-api/send/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { processPublicApiSend } from "@/lib/public-api/send-worker";
+
+function verifyWorkerSecret(request: NextRequest): boolean {
+  const secret = (process.env.CAMPAIGN_WORKER_SECRET || "").trim();
+  if (!secret) return false;
+  return (request.headers.get("X-Worker-Secret") || "").trim() === secret;
+}
+
+export async function POST(request: NextRequest) {
+  if (!verifyWorkerSecret(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const body = (await request.json()) as { mailId?: string; notificationId?: string };
+    if (!body.mailId || !body.notificationId) {
+      return NextResponse.json({ error: "mailId and notificationId required" }, { status: 400 });
+    }
+    await processPublicApiSend(body.mailId, body.notificationId);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error("public-api send worker", e instanceof Error ? e.message : e);
+    return NextResponse.json({ error: "worker_failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/internal/public-api/webhook-deliver/route.ts
+++ b/src/app/api/internal/public-api/webhook-deliver/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { deliverWebhookJob } from "@/lib/public-api/webhook-dispatch";
+
+function verifyWorkerSecret(request: NextRequest): boolean {
+  const secret = (process.env.CAMPAIGN_WORKER_SECRET || "").trim();
+  if (!secret) return false;
+  return (request.headers.get("X-Worker-Secret") || "").trim() === secret;
+}
+
+export async function POST(request: NextRequest) {
+  if (!verifyWorkerSecret(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const body = (await request.json()) as { deliveryId?: string };
+    if (!body.deliveryId) {
+      return NextResponse.json({ error: "deliveryId required" }, { status: 400 });
+    }
+    await deliverWebhookJob(body.deliveryId);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error("public-api webhook worker", e instanceof Error ? e.message : e);
+    return NextResponse.json({ error: "worker_failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/batches/[id]/route.ts
+++ b/src/app/api/v1/batches/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse } from "@/lib/public-api/handler";
+import { getPublicBatch } from "@/lib/public-api/batches";
+import { invalidRequest } from "@/lib/public-api/errors";
+import { isBatchPublicId } from "@/lib/public-api/ids";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: Ctx) {
+  return handlePublicApi(request, { scope: "batches:read", rateBucket: "general" }, async (auth) => {
+    const { id } = await context.params;
+    if (!isBatchPublicId(id)) throw invalidRequest("invalid_id", "Invalid batch id.", "id");
+    const body = await getPublicBatch(auth, id);
+    return NextResponse.json(body);
+  });
+}

--- a/src/app/api/v1/batches/route.ts
+++ b/src/app/api/v1/batches/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse, readJsonLimited } from "@/lib/public-api/handler";
+import { beginIdempotency, completeIdempotency, failIdempotency, requestFingerprint } from "@/lib/public-api/idempotency";
+import { createPublicBatch } from "@/lib/public-api/batches";
+import { MAX_BATCH_BODY_BYTES } from "@/lib/public-api/validation";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+export async function POST(request: NextRequest) {
+  return handlePublicApi(
+    request,
+    { scope: "batches:write", rateBucket: "general", extraRateBucket: "batches" },
+    async (ctx) => {
+      const body = await readJsonLimited(request, MAX_BATCH_BODY_BYTES);
+      const idempotencyKey = request.headers.get("Idempotency-Key")?.trim() || null;
+      const begun = await beginIdempotency({
+        orgId: ctx.orgId,
+        environment: ctx.environment,
+        key: idempotencyKey,
+        fingerprint: requestFingerprint(body),
+      });
+      if (begun.replay) {
+        return NextResponse.json(begun.replay.body, { status: begun.replay.status });
+      }
+      try {
+        const result = await createPublicBatch(ctx, body);
+        await completeIdempotency(begun.docId, result.httpStatus, result.body);
+        return NextResponse.json(result.body, { status: result.httpStatus });
+      } catch (e) {
+        await failIdempotency(begun.docId);
+        throw e;
+      }
+    }
+  );
+}

--- a/src/app/api/v1/me/route.ts
+++ b/src/app/api/v1/me/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse } from "@/lib/public-api/handler";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+export async function GET(request: NextRequest) {
+  return handlePublicApi(request, { scope: "notifications:read", rateBucket: "general" }, async (ctx) => {
+    return NextResponse.json({
+      account: {
+        id: ctx.orgId,
+        name: ctx.orgName,
+        environment: ctx.environment,
+        test_mode: ctx.testMode,
+        scopes: ctx.scopes,
+      },
+    });
+  });
+}

--- a/src/app/api/v1/notifications/[id]/certificate/route.ts
+++ b/src/app/api/v1/notifications/[id]/certificate/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse } from "@/lib/public-api/handler";
+import { invalidRequest } from "@/lib/public-api/errors";
+import { isNotificationPublicId } from "@/lib/public-api/ids";
+import { getPublicCertificate } from "@/lib/public-api/notifications";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: Ctx) {
+  return handlePublicApi(request, { scope: "notifications:read", rateBucket: "general" }, async (auth) => {
+    const { id } = await context.params;
+    if (!isNotificationPublicId(id)) throw invalidRequest("invalid_id", "Invalid notification id.", "id");
+    const body = await getPublicCertificate(auth, id);
+    return NextResponse.json(body);
+  });
+}

--- a/src/app/api/v1/notifications/[id]/route.ts
+++ b/src/app/api/v1/notifications/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse } from "@/lib/public-api/handler";
+import { isNotificationPublicId } from "@/lib/public-api/ids";
+import { getPublicNotification } from "@/lib/public-api/notifications";
+import { invalidRequest } from "@/lib/public-api/errors";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: Ctx) {
+  return handlePublicApi(request, { scope: "notifications:read", rateBucket: "general" }, async (auth) => {
+    const { id } = await context.params;
+    if (!isNotificationPublicId(id)) throw invalidRequest("invalid_id", "Invalid notification id.", "id");
+    const body = await getPublicNotification(auth, id);
+    return NextResponse.json(body);
+  });
+}

--- a/src/app/api/v1/notifications/route.ts
+++ b/src/app/api/v1/notifications/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse, readJsonLimited } from "@/lib/public-api/handler";
+import { beginIdempotency, completeIdempotency, failIdempotency, requestFingerprint } from "@/lib/public-api/idempotency";
+import { createPublicNotification, listPublicNotifications } from "@/lib/public-api/notifications";
+import { MAX_NOTIFICATION_BODY_BYTES } from "@/lib/public-api/validation";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+export async function GET(request: NextRequest) {
+  return handlePublicApi(request, { scope: "notifications:read", rateBucket: "general" }, async (ctx) => {
+    const q = Object.fromEntries(request.nextUrl.searchParams.entries());
+    const result = await listPublicNotifications(ctx, q);
+    return NextResponse.json(result);
+  });
+}
+
+export async function POST(request: NextRequest) {
+  return handlePublicApi(
+    request,
+    { scope: "notifications:write", rateBucket: "general", extraRateBucket: "notifications" },
+    async (ctx) => {
+      const body = await readJsonLimited(request, MAX_NOTIFICATION_BODY_BYTES);
+      const idempotencyKey = request.headers.get("Idempotency-Key")?.trim() || null;
+      const begun = await beginIdempotency({
+        orgId: ctx.orgId,
+        environment: ctx.environment,
+        key: idempotencyKey,
+        fingerprint: requestFingerprint(body),
+      });
+      if (begun.replay) {
+        return NextResponse.json(begun.replay.body, { status: begun.replay.status });
+      }
+      try {
+        const result = await createPublicNotification(ctx, body);
+        await completeIdempotency(begun.docId, result.httpStatus, result.body);
+        return NextResponse.json(result.body, { status: result.httpStatus });
+      } catch (e) {
+        await failIdempotency(begun.docId);
+        throw e;
+      }
+    }
+  );
+}

--- a/src/app/api/v1/webhook-endpoints/[id]/route.ts
+++ b/src/app/api/v1/webhook-endpoints/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse, readJsonLimited } from "@/lib/public-api/handler";
+import { getWebhookEndpoint, publicWebhookEndpointView, updateWebhookEndpoint } from "@/lib/public-api/webhooks";
+import { invalidRequest } from "@/lib/public-api/errors";
+import { isWebhookEndpointPublicId } from "@/lib/public-api/ids";
+import { MAX_WEBHOOK_BODY_BYTES, patchWebhookEndpointSchema } from "@/lib/public-api/validation";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: Ctx) {
+  return handlePublicApi(request, { scope: "webhooks:read", rateBucket: "general" }, async (auth) => {
+    const { id } = await context.params;
+    if (!isWebhookEndpointPublicId(id)) throw invalidRequest("invalid_id", "Invalid webhook endpoint id.", "id");
+    const row = await getWebhookEndpoint(auth, id);
+    return NextResponse.json(publicWebhookEndpointView(row));
+  });
+}
+
+export async function PATCH(request: NextRequest, context: Ctx) {
+  return handlePublicApi(request, { scope: "webhooks:write", rateBucket: "general" }, async (auth) => {
+    const { id } = await context.params;
+    if (!isWebhookEndpointPublicId(id)) throw invalidRequest("invalid_id", "Invalid webhook endpoint id.", "id");
+    const raw = await readJsonLimited(request, MAX_WEBHOOK_BODY_BYTES);
+    const parsed = patchWebhookEndpointSchema.safeParse(raw);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      throw invalidRequest("invalid_request", issue?.message || "Invalid request.", issue?.path.join(".") || undefined);
+    }
+    const row = await updateWebhookEndpoint(auth, id, parsed.data);
+    return NextResponse.json(publicWebhookEndpointView(row));
+  });
+}
+
+export async function DELETE(request: NextRequest, context: Ctx) {
+  return handlePublicApi(request, { scope: "webhooks:write", rateBucket: "general" }, async (auth) => {
+    const { id } = await context.params;
+    if (!isWebhookEndpointPublicId(id)) throw invalidRequest("invalid_id", "Invalid webhook endpoint id.", "id");
+    const row = await updateWebhookEndpoint(auth, id, { enabled: false });
+    return NextResponse.json(publicWebhookEndpointView(row));
+  });
+}

--- a/src/app/api/v1/webhook-endpoints/route.ts
+++ b/src/app/api/v1/webhook-endpoints/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePublicApi, publicApiOptionsResponse, readJsonLimited } from "@/lib/public-api/handler";
+import { createWebhookEndpoint, listWebhookEndpoints } from "@/lib/public-api/webhooks";
+import { createWebhookEndpointSchema, MAX_WEBHOOK_BODY_BYTES } from "@/lib/public-api/validation";
+import { invalidRequest } from "@/lib/public-api/errors";
+
+export function OPTIONS() {
+  return publicApiOptionsResponse();
+}
+
+export async function GET(request: NextRequest) {
+  return handlePublicApi(request, { scope: "webhooks:read", rateBucket: "general" }, async (ctx) => {
+    const data = await listWebhookEndpoints(ctx);
+    return NextResponse.json({ data });
+  });
+}
+
+export async function POST(request: NextRequest) {
+  return handlePublicApi(request, { scope: "webhooks:write", rateBucket: "general" }, async (ctx) => {
+    const raw = await readJsonLimited(request, MAX_WEBHOOK_BODY_BYTES);
+    const parsed = createWebhookEndpointSchema.safeParse(raw);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      throw invalidRequest("invalid_request", issue?.message || "Invalid request.", issue?.path.join(".") || undefined);
+    }
+    const created = await createWebhookEndpoint(ctx, parsed.data);
+    return NextResponse.json(
+      { ...created.endpoint, secret: created.secret },
+      { status: 201 }
+    );
+  });
+}

--- a/src/app/api/whatsapp/webhook/route.ts
+++ b/src/app/api/whatsapp/webhook/route.ts
@@ -5,6 +5,7 @@ import { recordEventLeaf } from "@/lib/campaign-integrity";
 import { certifyMailHitoIfNeeded } from "@/lib/certification-polygon";
 import { recordProviderEvent, sha256Utf8 } from "@/lib/provider-events";
 import { verifyWhatsAppHubSignature } from "@/lib/whatsapp-webhook-auth";
+import { syncPublicApiNotificationFromMail } from "@/lib/public-api/status-sync";
 
 // Callback URL canónica en Meta Developer Portal (app 1022568949756440):
 //   https://notificas.com.ar/api/whatsapp/webhook
@@ -319,6 +320,19 @@ async function processStatus(
     metaTimestamp: timestamp,
     rawPayloadHash: extra?.inbound?.payloadHash ?? undefined,
   });
+  const publicHint =
+    statusType === "read"
+      ? "read"
+      : statusType === "delivered"
+        ? "delivered"
+        : statusType === "failed"
+          ? "failed"
+          : statusType === "sent"
+            ? "sent"
+            : undefined;
+  if (publicHint) {
+    void syncPublicApiNotificationFromMail(mailDocId, publicHint).catch(() => undefined);
+  }
 }
 
 async function syncCampaignMessage(
@@ -386,7 +400,7 @@ async function syncCampaignMessage(
             });
           }
         }
-        t.update(ref, update);
+    t.update(ref, update);
       });
     }
     if (statusType === 'delivered' || statusType === 'read') {

--- a/src/app/docs/api/embed/layout.tsx
+++ b/src/app/docs/api/embed/layout.tsx
@@ -1,0 +1,12 @@
+import { createPageMetadata } from "@/lib/seo";
+
+export const metadata = createPageMetadata({
+  title: "Insertar la API en tu web",
+  description:
+    "SDK y widget para disparar notificaciones certificadas desde tu sitio. La API key queda en tu servidor; el navegador habla con un proxy.",
+  path: "/docs/api/embed",
+});
+
+export default function EmbedApiLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/docs/api/embed/page.tsx
+++ b/src/app/docs/api/embed/page.tsx
@@ -65,7 +65,23 @@ export default function EmbedApiPage() {
 
   const copy = async (which: "html" | "js") => {
     const text = which === "html" ? SNIPPET : JS_SNIPPET;
-    await navigator.clipboard.writeText(text);
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        throw new Error("clipboard unavailable");
+      }
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "true");
+      ta.style.position = "fixed";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      ta.remove();
+    }
     setCopied(which);
     window.setTimeout(() => setCopied(null), 2000);
   };

--- a/src/app/docs/api/embed/page.tsx
+++ b/src/app/docs/api/embed/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { LandingHeader } from "@/components/landing-header";
+
+const SNIPPET = `<div
+  data-notificas-embed
+  data-proxy-url="/api/notificas"
+  data-channel="whatsapp"
+  data-template="notificacion_deuda_180_dias"
+  data-button-label="Enviar notificación certificada"
+></div>
+<script src="https://notificas.com.ar/sdk/v1/notificas.js" async></script>`;
+
+const JS_SNIPPET = `const client = Notificas.create({
+  proxyUrl: "/api/notificas",
+});
+
+const { id, status } = await client.sendCertifiedNotification({
+  channel: "whatsapp",
+  recipient: { name: "Ana Pérez", phone: "+5491112345678" },
+  template: "notificacion_deuda_180_dias",
+  variables: { nombre: "Ana Pérez", monto: "128400" },
+  reference: "CLIENTE-12345",
+});`;
+
+export default function EmbedApiPage() {
+  const [copied, setCopied] = useState<"html" | "js" | null>(null);
+  const [sdkReady, setSdkReady] = useState(false);
+
+  useEffect(() => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      'script[data-notificas-sdk="v1"]'
+    );
+    if (existing) {
+      setSdkReady(true);
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = "/sdk/v1/notificas.js";
+    script.async = true;
+    script.dataset.notificasSdk = "v1";
+    script.onload = () => setSdkReady(true);
+    document.body.appendChild(script);
+  }, []);
+
+  useEffect(() => {
+    if (!sdkReady) return;
+    const Notificas = (
+      window as unknown as {
+        Notificas?: { embed: (el: string, opts: Record<string, unknown>) => void };
+      }
+    ).Notificas;
+    if (!Notificas) return;
+    const host = document.querySelector("#notificas-live-demo");
+    if (!host || host.childElementCount > 0) return;
+    Notificas.embed("#notificas-live-demo", {
+      demo: true,
+      channel: "whatsapp",
+      template: "notificacion_deuda_180_dias",
+      buttonLabel: "Enviar (demo)",
+    });
+  }, [sdkReady]);
+
+  const copy = async (which: "html" | "js") => {
+    const text = which === "html" ? SNIPPET : JS_SNIPPET;
+    await navigator.clipboard.writeText(text);
+    setCopied(which);
+    window.setTimeout(() => setCopied(null), 2000);
+  };
+
+  return (
+    <div className="brand-canvas flex min-h-screen flex-col text-foreground">
+      <LandingHeader />
+      <main className="container max-w-3xl flex-1 px-4 py-12 sm:py-16">
+        <nav className="mb-6 text-sm text-muted-foreground">
+          <Link href="/" className="text-primary underline-offset-4 hover:underline">
+            Inicio
+          </Link>
+          <span aria-hidden> / </span>
+          <Link href="/docs/api" className="text-primary underline-offset-4 hover:underline">
+            API
+          </Link>
+          <span aria-hidden> / </span>
+          <span className="text-foreground">Insertar en tu web</span>
+        </nav>
+
+        <p className="text-sm font-medium text-primary">SDK web v1</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl">
+          Insertá Notificas en tu web
+        </h1>
+        <p className="mt-4 text-lg leading-relaxed text-muted-foreground">
+          Un script, un widget o un cliente JavaScript. El sitio dispara la
+          notificación; Notificas deja constancia del envío. La clave{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-sm">ntf_live_</code>{" "}
+          nunca va en el navegador: el widget habla con tu backend, y tu backend
+          habla con la API.
+        </p>
+
+        <div className="mt-8 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-relaxed text-amber-950 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
+          La constancia es evidencia técnica del envío (contenido, destinatario,
+          canal y sello). No es firma digital, acto notarial ni carta documento.
+        </div>
+
+        <section className="mt-12">
+          <h2 className="text-2xl font-semibold">1. Pegá esto</h2>
+          <p className="mt-2 text-muted-foreground">
+            En cualquier HTML. Reemplazá <code>/api/notificas</code> por el proxy
+            de tu servidor.
+          </p>
+          <div className="relative mt-4">
+            <pre className="overflow-x-auto rounded-2xl bg-zinc-950 p-5 text-sm leading-relaxed text-zinc-100">
+              <code>{SNIPPET}</code>
+            </pre>
+            <button
+              type="button"
+              onClick={() => void copy("html")}
+              className="absolute right-3 top-3 rounded-lg bg-white/10 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/20"
+            >
+              {copied === "html" ? "Copiado" : "Copiar"}
+            </button>
+          </div>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-2xl font-semibold">2. Probá el widget</h2>
+          <p className="mt-2 text-muted-foreground">
+            Demo local: no llama a la API real. En producción usá{" "}
+            <code>data-proxy-url</code> apuntando a tu servidor.
+          </p>
+          <div className="mt-6" id="notificas-live-demo" />
+          {!sdkReady ? (
+            <p className="mt-4 text-sm text-muted-foreground">Cargando widget…</p>
+          ) : null}
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-2xl font-semibold">3. Proxy en tu backend</h2>
+          <p className="mt-2 text-muted-foreground">
+            El navegador no debe ver la API key. Tu servidor recibe el pedido del
+            widget, agrega{" "}
+            <code>Authorization: Bearer ntf_live_…</code> y reenvía a{" "}
+            <code>https://notificas.com.ar/api/v1</code>.
+          </p>
+          <ul className="mt-4 list-disc space-y-2 pl-5 text-muted-foreground">
+            <li>
+              Next.js: <code>docs/examples/nextjs-proxy-route.ts</code>
+            </li>
+            <li>
+              Express: <code>docs/examples/express-proxy.js</code>
+            </li>
+            <li>
+              HTML de ejemplo: <code>docs/examples/embed.html</code>
+            </li>
+          </ul>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-2xl font-semibold">Cliente JavaScript</h2>
+          <p className="mt-2 text-muted-foreground">
+            Si preferís tu propio formulario, usá el mismo script:
+          </p>
+          <div className="relative mt-4">
+            <pre className="overflow-x-auto rounded-2xl bg-zinc-950 p-5 text-sm leading-relaxed text-zinc-100">
+              <code>{JS_SNIPPET}</code>
+            </pre>
+            <button
+              type="button"
+              onClick={() => void copy("js")}
+              className="absolute right-3 top-3 rounded-lg bg-white/10 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/20"
+            >
+              {copied === "js" ? "Copiado" : "Copiar"}
+            </button>
+          </div>
+        </section>
+
+        <section className="mt-12 space-y-3 text-muted-foreground">
+          <h2 className="text-2xl font-semibold text-foreground">Atributos del widget</h2>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              <code>data-proxy-url</code> — URL de tu backend (recomendado).
+            </li>
+            <li>
+              <code>data-api-key</code> — solo <code>ntf_test_</code> o con{" "}
+              <code>data-allow-browser-key</code> (no usar en producción).
+            </li>
+            <li>
+              <code>data-channel</code> — <code>whatsapp</code> o{" "}
+              <code>email</code>.
+            </li>
+            <li>
+              <code>data-template</code> — nombre de plantilla Meta (WhatsApp).
+            </li>
+            <li>
+              <code>data-button-label</code> — texto del botón.
+            </li>
+            <li>
+              <code>data-demo</code> — <code>true</code> para simular el envío.
+            </li>
+          </ul>
+        </section>
+
+        <p className="mt-12 text-sm text-muted-foreground">
+          Referencia REST:{" "}
+          <Link href="/docs/api" className="text-primary underline">
+            /docs/api
+          </Link>
+          .
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/app/docs/api/layout.tsx
+++ b/src/app/docs/api/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "API pública",
+  description: "Documentación OpenAPI de la API v1 de Notificas.",
+};
+
+export default function PublicApiDocsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/docs/api/page.tsx
+++ b/src/app/docs/api/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function PublicApiDocsPage() {
+  useEffect(() => {
+    const marker = document.createElement("script");
+    marker.id = "api-reference";
+    marker.setAttribute("data-url", "/openapi/v1.yaml");
+    document.body.appendChild(marker);
+
+    const src = document.createElement("script");
+    src.src = "https://cdn.jsdelivr.net/npm/@scalar/api-reference";
+    src.async = true;
+    document.body.appendChild(src);
+
+    return () => {
+      marker.remove();
+      src.remove();
+    };
+  }, []);
+
+  return <div className="min-h-screen bg-background" />;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,6 +10,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/", changeFrequency: "weekly", priority: 1 },
     { path: "/verify", changeFrequency: "monthly", priority: 0.9 },
     { path: "/signup", changeFrequency: "monthly", priority: 0.85 },
+    { path: "/docs/api", changeFrequency: "monthly", priority: 0.7 },
+    { path: "/docs/api/embed", changeFrequency: "monthly", priority: 0.7 },
     ...SEO_GUIDE_PAGES.map((page) => ({
       path: page.path,
       changeFrequency: "monthly" as const,

--- a/src/components/admin/admin-shell.tsx
+++ b/src/components/admin/admin-shell.tsx
@@ -51,6 +51,7 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
     if (pathname?.startsWith("/admin/campanas")) return "Campañas masivas";
     if (pathname?.startsWith("/admin/verificacion-meta")) return "Verificación Meta";
     if (pathname?.startsWith("/admin/plans")) return "Gestión de Planes y Precios";
+    if (pathname?.startsWith("/admin/api-keys")) return "API Keys";
     if (pathname?.startsWith("/admin/settings")) return "Configuración";
     return "Panel de Administración";
   };

--- a/src/components/admin/main-nav.tsx
+++ b/src/components/admin/main-nav.tsx
@@ -25,6 +25,7 @@ export const adminNavLinks = [
   { href: "/admin/verificacion-meta", label: "Verificación Meta" },
   { href: "/admin/plans", label: "Planes" },
   { href: "/admin/email-test", label: "Test Emails" },
+  { href: "/admin/api-keys", label: "API Keys" },
   { href: "/admin/settings", label: "Configuración" },
 ] as const
 

--- a/src/components/landing-header.tsx
+++ b/src/components/landing-header.tsx
@@ -20,6 +20,7 @@ const navLinks = [
   { href: "/#empresas", label: "Empresas" },
   { href: "/#guias", label: "Guías" },
   { href: "/verify", label: "Verificar certificado" },
+  { href: "/docs/api/embed", label: "API" },
   { href: "/#faq", label: "Preguntas frecuentes" },
 ];
 

--- a/src/lib/campaign-complete.ts
+++ b/src/lib/campaign-complete.ts
@@ -1,6 +1,7 @@
 import { FieldValue } from 'firebase-admin/firestore';
 import { getAdminDb } from '@/lib/firebase-admin';
 import { closeOpenBatches } from '@/lib/campaign-integrity';
+import { emitBatchCompletedIfApi } from '@/lib/public-api/status-sync';
 
 /** Marca la campaña completada si ya no quedan pendientes (y cierra tandas Merkle). */
 export async function maybeCompleteCampaign(
@@ -45,5 +46,8 @@ export async function maybeCompleteCampaign(
 
   void closeOpenBatches(campRef.id, true).catch((e) =>
     console.warn('⚠️ No se pudieron cerrar tandas al completar:', e?.message)
+  );
+  void emitBatchCompletedIfApi(campRef.id).catch((e) =>
+    console.warn('public-api batch completed:', e instanceof Error ? e.message : e)
   );
 }

--- a/src/lib/cloud-tasks.ts
+++ b/src/lib/cloud-tasks.ts
@@ -229,6 +229,29 @@ export async function enqueueCampaignCsvExport(payload: {
   );
 }
 
+export async function enqueuePublicApiSend(payload: { mailId: string; notificationId: string }): Promise<void> {
+  await enqueueTask(
+    '/api/internal/public-api/send',
+    payload,
+    `papi-send-${payload.notificationId}`,
+    0,
+    { localDetach: true }
+  );
+}
+
+export async function enqueuePublicApiWebhookDeliver(
+  payload: { deliveryId: string },
+  delaySeconds = 0
+): Promise<void> {
+  await enqueueTask(
+    '/api/internal/public-api/webhook-deliver',
+    payload,
+    `papi-wh-${payload.deliveryId}-${delaySeconds}`,
+    delaySeconds,
+    { localDetach: delaySeconds > 0 }
+  );
+}
+
 /** Cierra (o intenta cerrar) una tanda Merkle. delaySeconds=0 = inmediato (lleno). idle = cierre por inactividad. */
 export async function enqueueIntegrityClose(
   campaignId: string,

--- a/src/lib/email-server.ts
+++ b/src/lib/email-server.ts
@@ -46,6 +46,17 @@ export type CreateMailAdminParams = {
   /** Campaña admin simulada: la CF sendEmail no debe despachar Mailgun/Meta. */
   simulated?: boolean;
   waOnly?: boolean;
+  /** Campos de la API pública (opcional). No reemplazan createdBy/to/message. */
+  orgId?: string;
+  publicApiId?: string;
+  apiSource?: string;
+  apiKeyId?: string;
+  apiReference?: string;
+  apiMetadata?: Record<string, string>;
+  apiChannel?: string;
+  apiBatchId?: string;
+  testMode?: boolean;
+  requestId?: string;
 };
 
 /** Crea un documento en `mail` con Admin SDK (equivalente a scheduleEmail sin auto-fetch). */
@@ -79,6 +90,16 @@ export async function createMailDocumentAdmin(params: CreateMailAdminParams): Pr
     waUrlButton,
     simulated,
     waOnly,
+    orgId,
+    publicApiId,
+    apiSource,
+    apiKeyId,
+    apiReference,
+    apiMetadata,
+    apiChannel,
+    apiBatchId,
+    testMode,
+    requestId,
   } = params;
 
   const db = getAdminDb();
@@ -152,6 +173,16 @@ export async function createMailDocumentAdmin(params: CreateMailAdminParams): Pr
   if (contactRequest) payload.contactRequest = true;
   if (simulated) payload.simulated = true;
   if (waOnly) payload.waOnly = true;
+  if (orgId) payload.orgId = orgId;
+  if (publicApiId) payload.publicApiId = publicApiId;
+  if (apiSource) payload.apiSource = apiSource;
+  if (apiKeyId) payload.apiKeyId = apiKeyId;
+  if (apiReference) payload.apiReference = apiReference;
+  if (apiMetadata && Object.keys(apiMetadata).length) payload.apiMetadata = apiMetadata;
+  if (apiChannel) payload.apiChannel = apiChannel;
+  if (apiBatchId) payload.apiBatchId = apiBatchId;
+  if (testMode) payload.testMode = true;
+  if (requestId) payload.requestId = requestId;
 
   await mailRef.set(payload);
   return mailId;

--- a/src/lib/evidence-snapshot.ts
+++ b/src/lib/evidence-snapshot.ts
@@ -264,6 +264,8 @@ export async function sealEvidenceSnapshot(mailId: string): Promise<EvidenceSnap
     await persistSealedArtifacts(mailId, sealed).catch((e) =>
       console.warn("⚠️ WORM / constancia:", e instanceof Error ? e.message : e)
     );
+    const { syncPublicApiNotificationFromMail } = await import("@/lib/public-api/status-sync");
+    void syncPublicApiNotificationFromMail(mailId).catch(() => undefined);
   }
   return sealed;
 }

--- a/src/lib/public-api/api-key-format.ts
+++ b/src/lib/public-api/api-key-format.ts
@@ -1,0 +1,21 @@
+import { randomBytes } from "crypto";
+import type { ApiEnvironment } from "@/lib/public-api/types";
+
+const KEY_RE = /^(ntf_(live|test))_([A-Za-z0-9]{16,64})$/;
+
+export function parseApiKey(raw: string): { environment: ApiEnvironment; fullKey: string; prefix: string } | null {
+  const token = raw.trim();
+  const m = KEY_RE.exec(token);
+  if (!m) return null;
+  const environment: ApiEnvironment = m[2] === "test" ? "test" : "live";
+  const prefix = `${m[1]}_${m[3].slice(0, 4)}`;
+  return { environment, fullKey: token, prefix };
+}
+
+export function generateApiKeySecret(environment: ApiEnvironment): { fullKey: string; prefix: string } {
+  const body = randomBytes(24).toString("base64url").replace(/[^A-Za-z0-9]/g, "x").slice(0, 32);
+  const fullKey = `ntf_${environment}_${body}`;
+  const parsed = parseApiKey(fullKey);
+  if (!parsed) throw new Error("failed_to_generate_api_key");
+  return { fullKey, prefix: parsed.prefix };
+}

--- a/src/lib/public-api/api-keys.ts
+++ b/src/lib/public-api/api-keys.ts
@@ -1,0 +1,97 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { hashApiKey, timingSafeEqualText } from "@/lib/public-api/crypto";
+import { generateApiKeySecret, parseApiKey } from "@/lib/public-api/api-key-format";
+import { forbidden, notFound, unauthorized } from "@/lib/public-api/errors";
+import { newApiKeyId } from "@/lib/public-api/ids";
+import { DEFAULT_LIVE_SCOPES, type PublicApiScope } from "@/lib/public-api/scopes";
+import { COLLECTIONS, type ApiEnvironment, type ApiKeyRecord } from "@/lib/public-api/types";
+
+export { generateApiKeySecret, parseApiKey } from "@/lib/public-api/api-key-format";
+
+export async function createApiKey(params: {
+  orgId: string;
+  name: string;
+  environment: ApiEnvironment;
+  scopes?: PublicApiScope[];
+  createdBy: string;
+}): Promise<{ record: ApiKeyRecord; secret: string }> {
+  const db = getAdminDb();
+  const id = newApiKeyId();
+  const generated = generateApiKeySecret(params.environment);
+  const now = FieldValue.serverTimestamp();
+  const record: ApiKeyRecord = {
+    id,
+    orgId: params.orgId,
+    name: params.name.trim().slice(0, 80) || "default",
+    prefix: generated.prefix,
+    keyHash: hashApiKey(generated.fullKey),
+    environment: params.environment,
+    scopes: params.scopes?.length ? params.scopes : DEFAULT_LIVE_SCOPES,
+    status: "active",
+    createdAt: now,
+    lastUsedAt: null,
+    createdBy: params.createdBy,
+  };
+  await db.collection(COLLECTIONS.apiKeys).doc(id).set(record);
+  return { record, secret: generated.fullKey };
+}
+
+export async function revokeApiKey(params: { keyId: string; orgId?: string }): Promise<void> {
+  const db = getAdminDb();
+  const ref = db.collection(COLLECTIONS.apiKeys).doc(params.keyId);
+  const snap = await ref.get();
+  if (!snap.exists) throw notFound("api_key_not_found", "API key not found.");
+  const data = snap.data() as ApiKeyRecord;
+  if (params.orgId && data.orgId !== params.orgId) {
+    throw forbidden("tenant_mismatch", "This API key does not belong to the requested account.");
+  }
+  await ref.update({ status: "revoked", revokedAt: FieldValue.serverTimestamp() });
+}
+
+export async function listApiKeys(orgId: string): Promise<Array<Omit<ApiKeyRecord, "keyHash">>> {
+  const db = getAdminDb();
+  const snap = await db.collection(COLLECTIONS.apiKeys).where("orgId", "==", orgId).get();
+  return snap.docs
+    .map((d) => {
+      const data = d.data() as ApiKeyRecord;
+      const { keyHash: _omit, ...rest } = data;
+      void _omit;
+      return { ...rest, id: d.id };
+    })
+    .sort((a, b) => String(a.prefix).localeCompare(String(b.prefix)));
+}
+
+export async function authenticateBearerToken(authorization: string | null): Promise<ApiKeyRecord> {
+  const raw = authorization?.startsWith("Bearer ") ? authorization.slice(7).trim() : "";
+  if (!raw) throw unauthorized();
+  const parsed = parseApiKey(raw);
+  if (!parsed) throw unauthorized();
+
+  const db = getAdminDb();
+  const hash = hashApiKey(parsed.fullKey);
+  const snap = await db.collection(COLLECTIONS.apiKeys).where("keyHash", "==", hash).limit(2).get();
+  if (snap.empty) throw unauthorized();
+  if (snap.size > 1) throw unauthorized("invalid_api_key", "Invalid API key.");
+
+  const data = { id: snap.docs[0].id, ...(snap.docs[0].data() as Omit<ApiKeyRecord, "id">) };
+  if (data.status !== "active") throw unauthorized("revoked_api_key", "This API key has been revoked.");
+  if (data.environment !== parsed.environment) throw unauthorized();
+  if (!timingSafeEqualText(data.keyHash, hash)) throw unauthorized();
+  return data;
+}
+
+export async function touchApiKeyLastUsed(keyId: string): Promise<void> {
+  try {
+    await getAdminDb().collection(COLLECTIONS.apiKeys).doc(keyId).update({
+      lastUsedAt: FieldValue.serverTimestamp(),
+    });
+  } catch {
+    // no bloquear el request
+  }
+}
+
+/** Nunca loguear el secret. Solo id/prefix. */
+export function redactApiKeyForLogs(key: Pick<ApiKeyRecord, "id" | "prefix" | "orgId">): string {
+  return `apiKey=${key.id} prefix=${key.prefix} org=${key.orgId}`;
+}

--- a/src/lib/public-api/audit.ts
+++ b/src/lib/public-api/audit.ts
@@ -1,0 +1,26 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { COLLECTIONS } from "@/lib/public-api/types";
+
+/** Auditoría sin secretos: nunca persistir Authorization, API keys, webhook secrets ni bodies crudos. */
+export async function writeApiAudit(entry: {
+  requestId: string;
+  apiKeyId?: string;
+  orgId?: string;
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  notificationId?: string;
+  batchId?: string;
+  errorCode?: string;
+}): Promise<void> {
+  try {
+    await getAdminDb().collection(COLLECTIONS.apiAudit).add({
+      ...entry,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  } catch (e) {
+    console.warn("public-api audit skipped", e instanceof Error ? e.message : e);
+  }
+}

--- a/src/lib/public-api/batches.ts
+++ b/src/lib/public-api/batches.ts
@@ -1,0 +1,275 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { saveAllRecipientChunks } from "@/lib/campaign-recipients-storage";
+import { startCampaignTanda } from "@/lib/campaign-start-tanda";
+import { maxRecipientsForPlan } from "@/lib/org-limits-client";
+import { isSyntheticCampaignEmail, presentRecipientValue, recipientValueText } from "@/lib/parse-campaign-csv";
+import type { CanalCampaign, RecipientEntry } from "@/lib/types";
+import { usesNotificasDefaultTemplate, WA_DEFAULT_TEMPLATE_NAME } from "@/lib/wa-template-fields";
+import { mapSavedWaTemplate } from "@/lib/wa-saved-template";
+import { invalidRequest, notFound, PublicApiError, unprocessable } from "@/lib/public-api/errors";
+import { newBatchId } from "@/lib/public-api/ids";
+import { isSandboxRecipientAllowed, mergeAllowlist } from "@/lib/public-api/sandbox";
+import { normalizeBatchStatus } from "@/lib/public-api/status";
+import { assertTenant } from "@/lib/public-api/tenant";
+import type { PublicApiAuthContext } from "@/lib/public-api/types";
+import { COLLECTIONS } from "@/lib/public-api/types";
+import {
+  createBatchSchema,
+  isValidEmail,
+  MAX_BATCH_RECIPIENTS,
+  normalizePhoneOrError,
+  sanitizeMetadata,
+  sanitizeVariables,
+} from "@/lib/public-api/validation";
+import { emitPublicApiEvent } from "@/lib/public-api/webhooks";
+
+function toIso(value: unknown): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && value && "toDate" in value && typeof (value as { toDate: () => Date }).toDate === "function") {
+    try {
+      return (value as { toDate: () => Date }).toDate().toISOString();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+async function resolveTemplate(orgId: string, template: string | undefined, channel: "whatsapp" | "email") {
+  const name = (template || "").trim();
+  if (!name || usesNotificasDefaultTemplate(name) || name === WA_DEFAULT_TEMPLATE_NAME) {
+    return { templateName: "", templateLang: "es_AR", templateVariables: [] as string[], urlButton: false, useDefault: true };
+  }
+  const snap = await getAdminDb().collection("wa_templates").where("orgId", "==", orgId).get();
+  const match = snap.docs
+    .map((d) => mapSavedWaTemplate(d.id, d.data() as Record<string, unknown>))
+    .find(
+      (t) =>
+        t.id === name ||
+        t.templateName.toLowerCase() === name.toLowerCase() ||
+        t.label.toLowerCase() === name.toLowerCase()
+    );
+  if (!match) {
+    if (channel === "email") return { templateName: "", templateLang: "es_AR", templateVariables: [] as string[], urlButton: false, useDefault: true };
+    throw unprocessable("unknown_template", "The template is not available for this account.", "template");
+  }
+  return {
+    templateName: match.templateName,
+    templateLang: match.templateLang,
+    templateVariables: match.templateVariables,
+    urlButton: match.urlButton,
+    useDefault: false,
+  };
+}
+
+export async function createPublicBatch(ctx: PublicApiAuthContext, rawBody: unknown) {
+  const parsed = createBatchSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw invalidRequest("invalid_request", issue?.message || "Invalid request.", issue?.path.join(".") || undefined);
+  }
+  const input = parsed.data;
+  if (input.recipients.length > MAX_BATCH_RECIPIENTS) {
+    throw invalidRequest("too_many_recipients", `A batch cannot exceed ${MAX_BATCH_RECIPIENTS} recipients.`, "recipients");
+  }
+
+  const orgSnap = await getAdminDb().collection("organizations").doc(ctx.orgId).get();
+  const org = orgSnap.data() || {};
+  const planMax = maxRecipientsForPlan(String(org.plan || "starter"));
+  if (input.recipients.length > planMax) {
+    throw unprocessable("plan_limit", `This plan allows at most ${planMax} recipients per batch.`, "recipients");
+  }
+
+  const tpl = await resolveTemplate(ctx.orgId, input.template, input.channel);
+  const allowlist = mergeAllowlist({
+    phones: Array.isArray(org.apiSandboxAllowlist?.phones) ? org.apiSandboxAllowlist.phones.map(String) : [],
+    emails: Array.isArray(org.apiSandboxAllowlist?.emails) ? org.apiSandboxAllowlist.emails.map(String) : [],
+  });
+
+  const recipients: RecipientEntry[] = [];
+  for (let i = 0; i < input.recipients.length; i++) {
+    const row = input.recipients[i];
+    const vars = sanitizeVariables(row.variables);
+    let phone: string | undefined;
+    let email: string | undefined;
+    if (input.channel === "whatsapp") {
+      const n = normalizePhoneOrError(row.phone);
+      if (!n.ok) throw invalidRequest("invalid_phone", `Recipient ${i} has an invalid phone number.`, `recipients.${i}.phone`);
+      phone = n.phone;
+      if (row.email) {
+        if (!isValidEmail(row.email)) throw invalidRequest("invalid_email", `Recipient ${i} has an invalid email.`, `recipients.${i}.email`);
+        email = row.email.trim().toLowerCase();
+      }
+    } else {
+      if (!row.email || !isValidEmail(row.email)) {
+        throw invalidRequest("invalid_email", `Recipient ${i} has an invalid email.`, `recipients.${i}.email`);
+      }
+      email = row.email.trim().toLowerCase();
+      if (row.phone) {
+        const n = normalizePhoneOrError(row.phone);
+        if (!n.ok) throw invalidRequest("invalid_phone", `Recipient ${i} has an invalid phone number.`, `recipients.${i}.phone`);
+        phone = n.phone;
+      }
+    }
+    if (ctx.testMode && !isSandboxRecipientAllowed({ allowlist, phone, email })) {
+      // sandbox batch: still accepted; campaign.simulated=true so CF no despacha
+    }
+    const nombre = row.name?.trim() || vars.nombre || "Destinatario";
+    recipients.push({
+      email: email && !isSyntheticCampaignEmail(email) ? email : `wa-${(phone || "").replace(/\D/g, "")}@notificas.internal`,
+      nombre,
+      telefono: phone,
+      dni: (row.document || vars.dni || "").replace(/\D/g, "") || undefined,
+      dias: vars.dias,
+      fecha: vars.fecha,
+      monto: vars.monto,
+      cuotas: presentRecipientValue(vars.cuotas) ? recipientValueText(vars.cuotas) : undefined,
+    });
+  }
+
+  const simulate = ctx.testMode && recipients.every((r) =>
+    !isSandboxRecipientAllowed({ allowlist, phone: r.telefono, email: isSyntheticCampaignEmail(r.email) ? undefined : r.email })
+  );
+
+  const publicId = newBatchId(ctx.testMode);
+  const canal: CanalCampaign = input.channel === "whatsapp" ? "whatsapp" : "email";
+  const db = getAdminDb();
+  const campRef = db.collection("campaigns").doc();
+  const metadata = sanitizeMetadata(input.metadata as Record<string, string | number | boolean> | undefined);
+
+  await campRef.set({
+    orgId: ctx.orgId,
+    createdBy: ctx.senderUid,
+    senderUid: ctx.senderUid,
+    senderEmail: ctx.senderEmail,
+    nombre: `API batch ${publicId}`,
+    asunto: input.subject || "Notificación",
+    cuerpo: input.body || "",
+    adjuntos: [],
+    canal,
+    estado: "borrador",
+    recipientCount: recipients.length,
+    recipientEmails: [],
+    recipientData: [],
+    stats: { total: recipients.length, enviados: 0, leidos: 0, pendientes: recipients.length, errores: 0 },
+    createdAt: FieldValue.serverTimestamp(),
+    apiSource: "public_api",
+    publicApiBatchId: publicId,
+    publicApiTestMode: ctx.testMode,
+    apiKeyId: ctx.apiKeyId,
+    apiReference: input.reference || null,
+    apiMetadata: metadata,
+    simulated: simulate,
+    ...(tpl.useDefault
+      ? {}
+      : {
+          waTemplateName: tpl.templateName,
+          waTemplateLang: tpl.templateLang,
+          waTemplateVariables: tpl.templateVariables,
+          waUrlButton: tpl.urlButton,
+        }),
+  });
+
+  await saveAllRecipientChunks(ctx.orgId, campRef.id, recipients);
+
+  await db.collection(COLLECTIONS.apiBatches).doc(publicId).set({
+    id: publicId,
+    orgId: ctx.orgId,
+    campaignId: campRef.id,
+    channel: input.channel,
+    status: "queued",
+    total: recipients.length,
+    reference: input.reference || null,
+    testMode: ctx.testMode,
+    apiKeyId: ctx.apiKeyId,
+    createdAt: FieldValue.serverTimestamp(),
+    requestId: ctx.requestId,
+  });
+
+  try {
+    await startCampaignTanda({
+      campaignId: campRef.id,
+      actorUid: ctx.senderUid,
+      actorEmail: ctx.senderEmail,
+      requireStorage: true,
+      chargeCredits: !simulate,
+      maxRecipients: planMax,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Could not queue the batch.";
+    const status = typeof (e as { status?: number }).status === "number" ? (e as { status: number }).status : 422;
+    throw new PublicApiError({
+      httpStatus: status === 404 ? 404 : 422,
+      type: status === 404 ? "not_found" : "validation_error",
+      code: "batch_queue_failed",
+      message: msg,
+    });
+  }
+
+  await emitPublicApiEvent({
+    type: "notification.queued",
+    orgId: ctx.orgId,
+    environment: ctx.environment,
+    data: { batch_id: publicId, status: "queued", total: recipients.length },
+  }).catch(() => undefined);
+
+  return {
+    httpStatus: 201,
+    body: {
+      id: publicId,
+      status: "queued",
+      total: recipients.length,
+      channel: input.channel,
+      ...(ctx.testMode ? { test_mode: true } : {}),
+    },
+  };
+}
+
+export async function getPublicBatch(ctx: PublicApiAuthContext, id: string) {
+  const snap = await getAdminDb().collection(COLLECTIONS.apiBatches).doc(id).get();
+  if (!snap.exists) throw notFound("batch_not_found", "Batch not found.");
+  const data = snap.data()!;
+  assertTenant(String(data.orgId || ""), ctx.orgId);
+  if (Boolean(data.testMode) !== ctx.testMode) throw notFound("batch_not_found", "Batch not found.");
+
+  const campaignId = String(data.campaignId || "");
+  const campSnap = await getAdminDb().collection("campaigns").doc(campaignId).get();
+  const camp = campSnap.data() || {};
+  const stats = (camp.stats || {}) as {
+    total?: number;
+    enviados?: number;
+    leidos?: number;
+    pendientes?: number;
+    errores?: number;
+  };
+
+  const db = getAdminDb();
+  const [deliveredSnap, readSnap] = await Promise.all([
+    db.collection("campaign_messages").where("campaignId", "==", campaignId).where("waEstado", "==", "entregado").count().get(),
+    db.collection("campaign_messages").where("campaignId", "==", campaignId).where("waEstado", "==", "leido").count().get(),
+  ]);
+
+  const total = typeof camp.recipientCount === "number" ? camp.recipientCount : Number(data.total || 0);
+  const sent = typeof stats.enviados === "number" ? stats.enviados : 0;
+  const failed = typeof stats.errores === "number" ? stats.errores : 0;
+  const queued = typeof stats.pendientes === "number" ? stats.pendientes : Math.max(0, total - sent - failed);
+  const delivered = deliveredSnap.data().count;
+  const read = typeof stats.leidos === "number" && stats.leidos > 0 ? stats.leidos : readSnap.data().count;
+
+  return {
+    id,
+    status: normalizeBatchStatus(camp.estado || data.status),
+    total,
+    queued,
+    sent,
+    delivered,
+    read,
+    failed,
+    channel: data.channel || camp.canal || null,
+    created_at: toIso(data.createdAt) || toIso(camp.createdAt),
+    ...(data.testMode ? { test_mode: true } : {}),
+  };
+}

--- a/src/lib/public-api/crypto.ts
+++ b/src/lib/public-api/crypto.ts
@@ -1,0 +1,74 @@
+import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes, timingSafeEqual } from "crypto";
+
+export function sha256Hex(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function hmacSha256Hex(secret: string, payload: string): string {
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  const left = Buffer.from(a, "utf8");
+  const right = Buffer.from(b, "utf8");
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+export function timingSafeEqualText(a: string, b: string): boolean {
+  const left = Buffer.from(a, "utf8");
+  const right = Buffer.from(b, "utf8");
+  if (left.length !== right.length) {
+    const dummy = Buffer.alloc(left.length);
+    timingSafeEqual(left, dummy);
+    return false;
+  }
+  return timingSafeEqual(left, right);
+}
+
+export function randomSecret(bytes = 32): string {
+  return randomBytes(bytes).toString("base64url");
+}
+
+function encryptionKey(): Buffer {
+  const raw =
+    process.env.PUBLIC_API_ENCRYPTION_KEY ||
+    process.env.PUBLIC_API_KEY_PEPPER ||
+    process.env.ADMIN_SESSION_SECRET ||
+    process.env.CAMPAIGN_WORKER_SECRET ||
+    "notificas-dev-public-api-encryption";
+  return createHash("sha256").update(`enc:${raw}`).digest();
+}
+
+/** AES-256-GCM. El valor en claro nunca debe loguearse. */
+export function encryptSecret(plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", encryptionKey(), iv);
+  const enc = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `v1:${iv.toString("base64url")}:${tag.toString("base64url")}:${enc.toString("base64url")}`;
+}
+
+export function decryptSecret(payload: string): string {
+  const parts = payload.split(":");
+  if (parts.length !== 4 || parts[0] !== "v1") {
+    throw new Error("invalid_encrypted_secret");
+  }
+  const iv = Buffer.from(parts[1], "base64url");
+  const tag = Buffer.from(parts[2], "base64url");
+  const enc = Buffer.from(parts[3], "base64url");
+  const decipher = createDecipheriv("aes-256-gcm", encryptionKey(), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(enc), decipher.final()]).toString("utf8");
+}
+
+export function apiKeyPepper(): string {
+  return (
+    process.env.PUBLIC_API_KEY_PEPPER ||
+    sha256Hex(`notificas-api-key-pepper:${process.env.ADMIN_SESSION_SECRET || process.env.CAMPAIGN_WORKER_SECRET || "dev"}`)
+  );
+}
+
+export function hashApiKey(fullKey: string): string {
+  return sha256Hex(`${apiKeyPepper()}\n${fullKey}`);
+}

--- a/src/lib/public-api/cursor.ts
+++ b/src/lib/public-api/cursor.ts
@@ -1,0 +1,20 @@
+export type ListCursor = {
+  createdAtMs: number;
+  id: string;
+};
+
+export function encodeCursor(cursor: ListCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+export function decodeCursor(raw: string | undefined | null): ListCursor | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8")) as ListCursor;
+    if (!parsed || typeof parsed.createdAtMs !== "number" || typeof parsed.id !== "string") return null;
+    if (!Number.isFinite(parsed.createdAtMs) || !parsed.id) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/public-api/errors.ts
+++ b/src/lib/public-api/errors.ts
@@ -1,0 +1,146 @@
+export type PublicApiErrorType =
+  | "authentication_error"
+  | "authorization_error"
+  | "validation_error"
+  | "not_found"
+  | "conflict"
+  | "rate_limit_error"
+  | "idempotency_error"
+  | "api_error";
+
+export type PublicApiErrorBody = {
+  error: {
+    type: PublicApiErrorType;
+    code: string;
+    message: string;
+    request_id: string;
+    param?: string;
+  };
+};
+
+export class PublicApiError extends Error {
+  readonly httpStatus: number;
+  readonly type: PublicApiErrorType;
+  readonly code: string;
+  readonly param?: string;
+
+  constructor(opts: {
+    httpStatus: number;
+    type: PublicApiErrorType;
+    code: string;
+    message: string;
+    param?: string;
+  }) {
+    super(opts.message);
+    this.name = "PublicApiError";
+    this.httpStatus = opts.httpStatus;
+    this.type = opts.type;
+    this.code = opts.code;
+    this.param = opts.param;
+  }
+}
+
+export function errorBody(err: PublicApiError, requestId: string): PublicApiErrorBody {
+  return {
+    error: {
+      type: err.type,
+      code: err.code,
+      message: err.message,
+      request_id: requestId,
+      ...(err.param ? { param: err.param } : {}),
+    },
+  };
+}
+
+export function invalidRequest(code: string, message: string, param?: string): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 400,
+    type: "validation_error",
+    code,
+    message,
+    param,
+  });
+}
+
+export function unauthorized(code = "invalid_api_key", message = "Invalid API key."): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 401,
+    type: "authentication_error",
+    code,
+    message,
+  });
+}
+
+export function forbidden(code: string, message: string): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 403,
+    type: "authorization_error",
+    code,
+    message,
+  });
+}
+
+export function notFound(code: string, message: string): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 404,
+    type: "not_found",
+    code,
+    message,
+  });
+}
+
+export function conflict(code: string, message: string): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 409,
+    type: "conflict",
+    code,
+    message,
+  });
+}
+
+export function unprocessable(code: string, message: string, param?: string): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 422,
+    type: "validation_error",
+    code,
+    message,
+    param,
+  });
+}
+
+export function rateLimited(retryAfterSeconds: number): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 429,
+    type: "rate_limit_error",
+    code: "rate_limited",
+    message: `Too many requests. Retry after ${retryAfterSeconds} seconds.`,
+  });
+}
+
+export function internalError(): PublicApiError {
+  return new PublicApiError({
+    httpStatus: 500,
+    type: "api_error",
+    code: "internal_error",
+    message: "An internal error occurred.",
+  });
+}
+
+export function httpStatusForType(type: PublicApiErrorType): number {
+  switch (type) {
+    case "authentication_error":
+      return 401;
+    case "authorization_error":
+      return 403;
+    case "validation_error":
+      return 400;
+    case "not_found":
+      return 404;
+    case "conflict":
+      return 409;
+    case "rate_limit_error":
+      return 429;
+    default:
+      return 500;
+  }
+}

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { authenticateBearerToken, touchApiKeyLastUsed } from "@/lib/public-api/api-keys";
+import { writeApiAudit } from "@/lib/public-api/audit";
+import { errorBody, forbidden, PublicApiError, unauthorized } from "@/lib/public-api/errors";
+import { newRequestId } from "@/lib/public-api/ids";
+import { consumeRateLimit } from "@/lib/public-api/rate-limit";
+import type { RateBucket } from "@/lib/public-api/rate-limit-config";
+import { hasScope, type PublicApiScope } from "@/lib/public-api/scopes";
+import type { PublicApiAuthContext } from "@/lib/public-api/types";
+
+export const PUBLIC_API_CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Request-Id",
+  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+  "Access-Control-Max-Age": "86400",
+};
+
+export function publicApiOptionsResponse(): NextResponse {
+  return new NextResponse(null, { status: 204, headers: PUBLIC_API_CORS_HEADERS });
+}
+
+function requestIdFrom(request: NextRequest): string {
+  const incoming = request.headers.get("X-Request-Id")?.trim();
+  if (incoming && /^[a-zA-Z0-9_.:-]{8,80}$/.test(incoming)) return incoming;
+  return newRequestId();
+}
+
+export function withApiHeaders(
+  response: NextResponse,
+  requestId: string,
+  extra?: Record<string, string>
+): NextResponse {
+  response.headers.set("X-Request-Id", requestId);
+  for (const [k, v] of Object.entries(PUBLIC_API_CORS_HEADERS)) response.headers.set(k, v);
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) response.headers.set(k, v);
+  }
+  return response;
+}
+
+export function jsonApiError(err: PublicApiError, requestId: string, extraHeaders?: Record<string, string>): NextResponse {
+  const res = NextResponse.json(errorBody(err, requestId), { status: err.httpStatus });
+  return withApiHeaders(res, requestId, extraHeaders);
+}
+
+export async function readJsonLimited(request: NextRequest, maxBytes: number): Promise<unknown> {
+  const len = Number(request.headers.get("content-length") || "0");
+  if (Number.isFinite(len) && len > maxBytes) {
+    throw new PublicApiError({
+      httpStatus: 413,
+      type: "validation_error",
+      code: "payload_too_large",
+      message: `Request body exceeds ${maxBytes} bytes.`,
+    });
+  }
+  const buf = Buffer.from(await request.arrayBuffer());
+  if (buf.length > maxBytes) {
+    throw new PublicApiError({
+      httpStatus: 413,
+      type: "validation_error",
+      code: "payload_too_large",
+      message: `Request body exceeds ${maxBytes} bytes.`,
+    });
+  }
+  if (buf.length === 0) return {};
+  try {
+    return JSON.parse(buf.toString("utf8"));
+  } catch {
+    throw new PublicApiError({
+      httpStatus: 400,
+      type: "validation_error",
+      code: "invalid_json",
+      message: "The request body is not valid JSON.",
+    });
+  }
+}
+
+export async function resolveAuthContext(request: NextRequest): Promise<PublicApiAuthContext> {
+  const requestId = requestIdFrom(request);
+  const key = await authenticateBearerToken(request.headers.get("Authorization"));
+  const db = getAdminDb();
+  const orgSnap = await db.collection("organizations").doc(key.orgId).get();
+  if (!orgSnap.exists) throw unauthorized("invalid_api_key", "Invalid API key.");
+  const org = orgSnap.data()!;
+  const senderUid = String(org.adminUserId || "");
+  if (!senderUid) throw unauthorized("invalid_api_key", "Invalid API key.");
+  void touchApiKeyLastUsed(key.id);
+  return {
+    requestId,
+    apiKeyId: key.id,
+    apiKeyPrefix: key.prefix,
+    orgId: key.orgId,
+    orgName: String(org.nombre || ""),
+    orgCuit: typeof org.cuit === "string" ? org.cuit : null,
+    senderUid,
+    senderEmail: String(org.adminUserEmail || ""),
+    environment: key.environment,
+    testMode: key.environment === "test",
+    scopes: Array.isArray(key.scopes) ? (key.scopes as PublicApiAuthContext["scopes"]) : [],
+  };
+}
+
+export async function handlePublicApi(
+  request: NextRequest,
+  opts: {
+    scope: PublicApiScope;
+    rateBucket: RateBucket;
+    extraRateBucket?: RateBucket;
+  },
+  handler: (ctx: PublicApiAuthContext) => Promise<NextResponse>
+): Promise<NextResponse> {
+  const started = Date.now();
+  const requestId = requestIdFrom(request);
+  let ctx: PublicApiAuthContext | null = null;
+  try {
+    ctx = await resolveAuthContext(request);
+    ctx.requestId = requestId;
+    if (!hasScope(ctx.scopes, opts.scope)) {
+      throw forbidden("insufficient_scope", "This API key does not have permission for this endpoint.");
+    }
+    try {
+      await consumeRateLimit({
+        apiKeyId: ctx.apiKeyId,
+        orgId: ctx.orgId,
+        bucket: opts.rateBucket,
+        extra: opts.extraRateBucket,
+      });
+    } catch (e) {
+      if (e instanceof PublicApiError && e.httpStatus === 429) {
+        const retry = Number((e as PublicApiError & { retryAfterSeconds?: number }).retryAfterSeconds || 60);
+        const res = jsonApiError(e, requestId, { "Retry-After": String(retry) });
+        void writeApiAudit({
+          requestId,
+          apiKeyId: ctx.apiKeyId,
+          orgId: ctx.orgId,
+          method: request.method,
+          path: request.nextUrl.pathname,
+          status: 429,
+          durationMs: Date.now() - started,
+          errorCode: "rate_limited",
+        });
+        return res;
+      }
+      throw e;
+    }
+    const response = await handler(ctx);
+    const out = withApiHeaders(response, requestId);
+    void writeApiAudit({
+      requestId,
+      apiKeyId: ctx.apiKeyId,
+      orgId: ctx.orgId,
+      method: request.method,
+      path: request.nextUrl.pathname,
+      status: out.status,
+      durationMs: Date.now() - started,
+    });
+    return out;
+  } catch (e) {
+    const err =
+      e instanceof PublicApiError
+        ? e
+        : new PublicApiError({
+            httpStatus: 500,
+            type: "api_error",
+            code: "internal_error",
+            message: "An internal error occurred.",
+          });
+    if (!(e instanceof PublicApiError)) {
+      console.error("public-api", requestId, e instanceof Error ? e.message : e);
+    }
+    const extra =
+      err.httpStatus === 429
+        ? { "Retry-After": String((err as PublicApiError & { retryAfterSeconds?: number }).retryAfterSeconds || 60) }
+        : undefined;
+    void writeApiAudit({
+      requestId,
+      apiKeyId: ctx?.apiKeyId,
+      orgId: ctx?.orgId,
+      method: request.method,
+      path: request.nextUrl.pathname,
+      status: err.httpStatus,
+      durationMs: Date.now() - started,
+      errorCode: err.code,
+    });
+    return jsonApiError(err, requestId, extra);
+  }
+}

--- a/src/lib/public-api/idempotency-hash.ts
+++ b/src/lib/public-api/idempotency-hash.ts
@@ -1,0 +1,13 @@
+import { createHash } from "crypto";
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(",")}}`;
+}
+
+export function requestFingerprint(body: unknown): string {
+  return createHash("sha256").update(canonicalJson(body)).digest("hex");
+}

--- a/src/lib/public-api/idempotency.ts
+++ b/src/lib/public-api/idempotency.ts
@@ -1,0 +1,101 @@
+import { createHash } from "crypto";
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { conflict, invalidRequest } from "@/lib/public-api/errors";
+import { isValidIdempotencyKey } from "@/lib/public-api/validation";
+import { COLLECTIONS } from "@/lib/public-api/types";
+
+export { canonicalJson, requestFingerprint } from "@/lib/public-api/idempotency-hash";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+export function idempotencyDocId(orgId: string, environment: string, key: string): string {
+  return createHash("sha256").update(`${orgId}\n${environment}\n${key}`).digest("hex");
+}
+
+export type IdempotencyHit = {
+  status: number;
+  body: unknown;
+};
+
+export async function beginIdempotency(opts: {
+  orgId: string;
+  environment: string;
+  key: string | null;
+  fingerprint: string;
+}): Promise<{ key: string | null; replay?: IdempotencyHit; docId?: string }> {
+  if (!opts.key) return { key: null };
+  if (!isValidIdempotencyKey(opts.key)) {
+    throw invalidRequest("invalid_idempotency_key", "The Idempotency-Key header is invalid.", "Idempotency-Key");
+  }
+  const db = getAdminDb();
+  const docId = idempotencyDocId(opts.orgId, opts.environment, opts.key);
+  const ref = db.collection(COLLECTIONS.apiIdempotency).doc(docId);
+
+  const result = await db.runTransaction(async (t) => {
+    const snap = await t.get(ref);
+    if (!snap.exists) {
+      t.set(ref, {
+        orgId: opts.orgId,
+        environment: opts.environment,
+        key: opts.key,
+        fingerprint: opts.fingerprint,
+        status: "processing",
+        createdAt: FieldValue.serverTimestamp(),
+        expiresAtMs: Date.now() + TTL_MS,
+      });
+      return { kind: "started" as const };
+    }
+    const data = snap.data()!;
+    const expired = typeof data.expiresAtMs === "number" && data.expiresAtMs < Date.now();
+    if (expired) {
+      t.set(ref, {
+        orgId: opts.orgId,
+        environment: opts.environment,
+        key: opts.key,
+        fingerprint: opts.fingerprint,
+        status: "processing",
+        createdAt: FieldValue.serverTimestamp(),
+        expiresAtMs: Date.now() + TTL_MS,
+      });
+      return { kind: "started" as const };
+    }
+    if (data.fingerprint !== opts.fingerprint) {
+      return { kind: "mismatch" as const };
+    }
+    if (data.status === "completed" && typeof data.responseStatus === "number") {
+      return {
+        kind: "replay" as const,
+        hit: { status: data.responseStatus as number, body: data.responseBody },
+      };
+    }
+    return { kind: "in_progress" as const };
+  });
+
+  if (result.kind === "mismatch") {
+    throw conflict(
+      "idempotency_key_reused",
+      "This Idempotency-Key was already used with a different request body."
+    );
+  }
+  if (result.kind === "in_progress") {
+    throw conflict("idempotency_in_progress", "A request with this Idempotency-Key is still being processed.");
+  }
+  if (result.kind === "replay") return { key: opts.key, replay: result.hit, docId };
+  return { key: opts.key, docId };
+}
+
+export async function completeIdempotency(docId: string | undefined, status: number, body: unknown): Promise<void> {
+  if (!docId) return;
+  await getAdminDb().collection(COLLECTIONS.apiIdempotency).doc(docId).update({
+    status: "completed",
+    responseStatus: status,
+    responseBody: body,
+    completedAt: FieldValue.serverTimestamp(),
+  });
+}
+
+export async function failIdempotency(docId: string | undefined): Promise<void> {
+  if (!docId) return;
+  await getAdminDb().collection(COLLECTIONS.apiIdempotency).doc(docId).delete().catch(() => undefined);
+}

--- a/src/lib/public-api/ids.ts
+++ b/src/lib/public-api/ids.ts
@@ -1,0 +1,64 @@
+import { randomBytes } from "crypto";
+
+/** Crockford Base32 (ULID). */
+const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+function encodeTime(now: number): string {
+  let time = now;
+  let out = "";
+  for (let i = 0; i < 10; i++) {
+    const mod = time % 32;
+    out = ENCODING[mod] + out;
+    time = Math.floor(time / 32);
+  }
+  return out;
+}
+
+function encodeRandom(bytes: Buffer): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += ENCODING[bytes[i] % 32];
+  }
+  return out;
+}
+
+/** Identificador público tipo ULID (26 chars). */
+export function newUlid(): string {
+  return encodeTime(Date.now()) + encodeRandom(randomBytes(16));
+}
+
+export function newRequestId(): string {
+  return `req_${newUlid()}`;
+}
+
+export function newNotificationId(testMode: boolean): string {
+  return testMode ? `ntf_test_${newUlid()}` : `ntf_${newUlid()}`;
+}
+
+export function newBatchId(testMode: boolean): string {
+  return testMode ? `batch_test_${newUlid()}` : `batch_${newUlid()}`;
+}
+
+export function newEventId(): string {
+  return `evt_${newUlid()}`;
+}
+
+export function newApiKeyId(): string {
+  return `key_${newUlid()}`;
+}
+
+export function newWebhookEndpointId(): string {
+  return `wh_${newUlid()}`;
+}
+
+export function isNotificationPublicId(id: string): boolean {
+  return /^ntf_(test_)?[0-9A-HJKMNP-TV-Z]{26}$/i.test(id.trim());
+}
+
+export function isBatchPublicId(id: string): boolean {
+  return /^batch_(test_)?[0-9A-HJKMNP-TV-Z]{26}$/i.test(id.trim());
+}
+
+export function isWebhookEndpointPublicId(id: string): boolean {
+  return /^wh_[0-9A-HJKMNP-TV-Z]{26}$/i.test(id.trim());
+}

--- a/src/lib/public-api/mask.ts
+++ b/src/lib/public-api/mask.ts
@@ -1,0 +1,24 @@
+export function maskPhone(phone: string | undefined | null): string | undefined {
+  const raw = String(phone || "").trim();
+  if (!raw) return undefined;
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length < 6) return `${raw.slice(0, 2)}****`;
+  const prefix = raw.startsWith("+") ? `+${digits.slice(0, 7)}` : digits.slice(0, 6);
+  return `${prefix}******`;
+}
+
+export function maskEmail(email: string | undefined | null): string | undefined {
+  const raw = String(email || "").trim().toLowerCase();
+  if (!raw || !raw.includes("@")) return undefined;
+  const [user, domain] = raw.split("@");
+  if (!user || !domain) return undefined;
+  const keep = user.slice(0, Math.min(2, user.length));
+  return `${keep}***@${domain}`;
+}
+
+export function maskDocument(doc: string | undefined | null): string | undefined {
+  const digits = String(doc || "").replace(/\D/g, "");
+  if (!digits) return undefined;
+  if (digits.length <= 4) return "****";
+  return `${digits.slice(0, 2)}****${digits.slice(-2)}`;
+}

--- a/src/lib/public-api/notifications.ts
+++ b/src/lib/public-api/notifications.ts
@@ -1,0 +1,503 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb, getAdminBucket } from "@/lib/firebase-admin";
+import { createMailDocumentAdmin } from "@/lib/email-server";
+import { enqueuePublicApiSend } from "@/lib/cloud-tasks";
+import { normalizeEnviosDisponibles } from "@/lib/envios";
+import { buildCampaignMailHtml, campaignBodyToHtmlFragment } from "@/lib/campaign-email-html";
+import { constanciaEnvioStoragePath } from "@/lib/constancia-envio-pdf";
+import { isSyntheticCampaignEmail, phoneDigits, presentRecipientValue } from "@/lib/parse-campaign-csv";
+import { usesNotificasDefaultTemplate, WA_DEFAULT_TEMPLATE_NAME } from "@/lib/wa-template-fields";
+import { mapSavedWaTemplate } from "@/lib/wa-saved-template";
+import { decodeCursor, encodeCursor } from "@/lib/public-api/cursor";
+import { invalidRequest, notFound, unprocessable } from "@/lib/public-api/errors";
+import { newNotificationId } from "@/lib/public-api/ids";
+import { maskEmail, maskPhone } from "@/lib/public-api/mask";
+import { isSandboxRecipientAllowed, mergeAllowlist, type SandboxAllowlist } from "@/lib/public-api/sandbox";
+import { assertTenant } from "@/lib/public-api/tenant";
+import {
+  certificateStatusFromMail,
+  normalizeNotificationStatus,
+  type PublicCertificateStatus,
+  type PublicNotificationStatus,
+} from "@/lib/public-api/status";
+import { emitPublicApiEvent } from "@/lib/public-api/webhooks";
+import type { PublicApiAuthContext } from "@/lib/public-api/types";
+import { COLLECTIONS } from "@/lib/public-api/types";
+import {
+  createNotificationSchema,
+  isValidEmail,
+  listNotificationsQuerySchema,
+  normalizePhoneOrError,
+  sanitizeMetadata,
+  sanitizeVariables,
+  type CreateNotificationInput,
+} from "@/lib/public-api/validation";
+
+function applyVariables(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_, key: string) => vars[key] ?? "");
+}
+
+function toIso(value: unknown): string | null {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  if (typeof value === "string") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? value : d.toISOString();
+  }
+  if (typeof value === "object" && value && "toDate" in value && typeof (value as { toDate: () => Date }).toDate === "function") {
+    try {
+      return (value as { toDate: () => Date }).toDate().toISOString();
+    } catch {
+      return null;
+    }
+  }
+  if (typeof value === "object" && value && typeof (value as { seconds?: number }).seconds === "number") {
+    return new Date((value as { seconds: number }).seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+type ResolvedTemplate = {
+  templateName: string;
+  templateLang: string;
+  templateVariables: string[];
+  urlButton: boolean;
+  useDefault: boolean;
+};
+
+async function resolveOrgTemplate(orgId: string, template: string | undefined, channel: "whatsapp" | "email"): Promise<ResolvedTemplate> {
+  const name = (template || "").trim();
+  if (!name || usesNotificasDefaultTemplate(name) || name === WA_DEFAULT_TEMPLATE_NAME) {
+    return {
+      templateName: WA_DEFAULT_TEMPLATE_NAME,
+      templateLang: "es_AR",
+      templateVariables: ["nombre", "remitente", "url_lectura"],
+      urlButton: false,
+      useDefault: true,
+    };
+  }
+
+  const db = getAdminDb();
+  const snap = await db.collection("wa_templates").where("orgId", "==", orgId).get();
+  const match = snap.docs
+    .map((d) => mapSavedWaTemplate(d.id, d.data() as Record<string, unknown>))
+    .find(
+      (t) =>
+        t.id === name ||
+        t.templateName.toLowerCase() === name.toLowerCase() ||
+        t.label.toLowerCase() === name.toLowerCase()
+    );
+  if (!match) {
+    if (channel === "email") {
+      return {
+        templateName: name,
+        templateLang: "es_AR",
+        templateVariables: [],
+        urlButton: false,
+        useDefault: true,
+      };
+    }
+    throw unprocessable(
+      "unknown_template",
+      "The template is not available for this account. Save it first in the WhatsApp templates of the organization.",
+      "template"
+    );
+  }
+  return {
+    templateName: match.templateName,
+    templateLang: match.templateLang,
+    templateVariables: match.templateVariables,
+    urlButton: match.urlButton,
+    useDefault: false,
+  };
+}
+
+function recipientSearchTokens(phone?: string, email?: string, document?: string): string[] {
+  const tokens = new Set<string>();
+  const digits = phoneDigits(phone);
+  if (digits) tokens.add(digits);
+  const em = (email || "").trim().toLowerCase();
+  if (em && !isSyntheticCampaignEmail(em)) tokens.add(em);
+  const doc = String(document || "").replace(/\D/g, "");
+  if (doc) tokens.add(doc);
+  return [...tokens];
+}
+
+export function serializeNotification(row: FirebaseFirestore.DocumentData, id: string) {
+  const channel = row.channel === "email" ? "email" : "whatsapp";
+  const recipient: Record<string, string> = {};
+  const maskedPhone = maskPhone(row.recipientPhone);
+  const maskedEmail = maskEmail(row.recipientEmail);
+  if (channel === "whatsapp" && maskedPhone) recipient.phone = maskedPhone;
+  if (channel === "email" && maskedEmail) recipient.email = maskedEmail;
+  if (channel === "whatsapp" && maskedEmail) recipient.email = maskedEmail;
+  return {
+    id,
+    status: row.status as PublicNotificationStatus,
+    channel,
+    recipient,
+    reference: row.reference || null,
+    created_at: toIso(row.createdAt),
+    sent_at: toIso(row.sentAt),
+    delivered_at: toIso(row.deliveredAt),
+    read_at: toIso(row.readAt),
+    failed_at: toIso(row.failedAt),
+    certificate_status: row.certificateStatus || "processing",
+    test_mode: row.testMode === true,
+  };
+}
+
+async function orgAllowlist(orgId: string): Promise<SandboxAllowlist> {
+  const snap = await getAdminDb().collection("organizations").doc(orgId).get();
+  const raw = snap.data()?.apiSandboxAllowlist;
+  return mergeAllowlist({
+    phones: Array.isArray(raw?.phones) ? raw.phones.map(String) : [],
+    emails: Array.isArray(raw?.emails) ? raw.emails.map(String) : [],
+  });
+}
+
+async function consumeCredit(uid: string): Promise<void> {
+  const db = getAdminDb();
+  const userRef = db.collection("users").doc(uid);
+  await db.runTransaction(async (t) => {
+    const snap = await t.get(userRef);
+    const available = normalizeEnviosDisponibles(snap.data()?.creditos);
+    if (available < 1) {
+      throw unprocessable("insufficient_credits", "The account has no remaining sends.");
+    }
+    t.update(userRef, {
+      creditos: FieldValue.increment(-1),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  });
+  await db.collection("user_transactions").add({
+    userId: uid,
+    tipo: "envio",
+    descripcion: "Envío API pública",
+    creditos: -1,
+    monto: 0,
+    createdAt: FieldValue.serverTimestamp(),
+    source: "public_api",
+  });
+}
+
+export async function createPublicNotification(
+  ctx: PublicApiAuthContext,
+  rawBody: unknown
+): Promise<{ httpStatus: number; body: Record<string, unknown> }> {
+  const parsed = createNotificationSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw invalidRequest("invalid_request", issue?.message || "Invalid request.", issue?.path.join(".") || undefined);
+  }
+  const input: CreateNotificationInput = parsed.data;
+  const variables = sanitizeVariables(input.variables);
+  const metadata = sanitizeMetadata(input.metadata as Record<string, string | number | boolean> | undefined);
+  const reference = input.reference?.trim() || null;
+
+  let phone: string | undefined;
+  let email: string | undefined;
+  if (input.channel === "whatsapp") {
+    const n = normalizePhoneOrError(input.recipient.phone);
+    if (!n.ok) throw invalidRequest("invalid_phone", "The recipient phone number is invalid.", "recipient.phone");
+    phone = n.phone;
+    if (input.recipient.email) {
+      if (!isValidEmail(input.recipient.email)) {
+        throw invalidRequest("invalid_email", "The recipient email is invalid.", "recipient.email");
+      }
+      email = input.recipient.email.trim().toLowerCase();
+    }
+  } else {
+    if (!input.recipient.email || !isValidEmail(input.recipient.email)) {
+      throw invalidRequest("invalid_email", "The recipient email is invalid.", "recipient.email");
+    }
+    email = input.recipient.email.trim().toLowerCase();
+    if (input.recipient.phone) {
+      const n = normalizePhoneOrError(input.recipient.phone);
+      if (!n.ok) throw invalidRequest("invalid_phone", "The recipient phone number is invalid.", "recipient.phone");
+      phone = n.phone;
+    }
+  }
+
+  const tpl = await resolveOrgTemplate(ctx.orgId, input.template, input.channel);
+  if (input.channel === "whatsapp" && !input.template && !tpl.useDefault) {
+    throw invalidRequest("missing_template", "A WhatsApp template is required.", "template");
+  }
+  if (input.channel === "email" && !input.subject && !input.body && !input.template) {
+    throw invalidRequest("missing_content", "Email notifications require subject and body, or a template.", "body");
+  }
+
+  const allowlist = await orgAllowlist(ctx.orgId);
+  const sandboxAllowed = ctx.testMode && isSandboxRecipientAllowed({ allowlist, phone, email });
+  const simulate = ctx.testMode && !sandboxAllowed;
+  const realSend = !simulate;
+
+  const publicId = newNotificationId(ctx.testMode);
+  const name = input.recipient.name?.trim() || variables.nombre || "Destinatario";
+  const document = (input.recipient.document || variables.dni || "").replace(/\D/g, "") || undefined;
+  const vars: Record<string, string> = {
+    ...variables,
+    nombre: variables.nombre || name,
+    dni: variables.dni || document || "",
+  };
+  const subject = applyVariables(input.subject || "Notificación", vars);
+  const bodyPlain = applyVariables(input.body || "", vars) || `${name}`;
+  const html = buildCampaignMailHtml({
+    recipientEmail: email || `wa-${phoneDigits(phone)}@notificas.internal`,
+    recipientName: name,
+    sender: ctx.senderEmail || ctx.orgName || "Notificas",
+    bodyHtml: campaignBodyToHtmlFragment(bodyPlain),
+    attachments: [],
+  });
+  const to = email && !isSyntheticCampaignEmail(email) ? email : `wa-${phoneDigits(phone)}@notificas.internal`;
+  const waOnly = input.channel === "whatsapp";
+
+  if (realSend) {
+    await consumeCredit(ctx.senderUid);
+  }
+
+  const mailId = await createMailDocumentAdmin({
+    to,
+    subject,
+    html,
+    text: bodyPlain,
+    from: "contacto@notificas.com",
+    replyTo: ctx.senderEmail.includes("@") ? ctx.senderEmail : undefined,
+    senderName: ctx.senderEmail || ctx.orgName,
+    recipientName: name,
+    recipientEmail: to,
+    recipientPhone: phone,
+    recipientDni: document,
+    recipientDias: vars.dias,
+    recipientFecha: vars.fecha,
+    recipientMonto: vars.monto,
+    recipientCuotas: presentRecipientValue(vars.cuotas) ? vars.cuotas : undefined,
+    createdBy: ctx.senderUid,
+    waOnly,
+    simulated: simulate,
+    orgId: ctx.orgId,
+    publicApiId: publicId,
+    apiSource: "public_api",
+    apiKeyId: ctx.apiKeyId,
+    apiReference: reference || undefined,
+    apiMetadata: metadata,
+    apiChannel: input.channel,
+    testMode: ctx.testMode,
+    requestId: ctx.requestId,
+    ...(tpl.useDefault
+      ? {}
+      : {
+          waTemplateName: tpl.templateName,
+          waTemplateLang: tpl.templateLang,
+          waTemplateVariables: tpl.templateVariables,
+          ...(tpl.urlButton ? { waUrlButton: true } : {}),
+        }),
+  });
+
+  const createdAt = new Date().toISOString();
+  const status: PublicNotificationStatus = simulate ? "delivered" : "queued";
+  const cert: PublicCertificateStatus = simulate ? "sandbox" : "processing";
+
+  await getAdminDb()
+    .collection(COLLECTIONS.apiNotifications)
+    .doc(publicId)
+    .set({
+      id: publicId,
+      orgId: ctx.orgId,
+      mailId,
+      channel: input.channel,
+      status,
+      reference,
+      recipientPhone: phone || null,
+      recipientEmail: email || null,
+      recipientName: name,
+      recipientSearch: recipientSearchTokens(phone, email, document),
+      createdAt: FieldValue.serverTimestamp(),
+      createdAtIso: createdAt,
+      ...(simulate ? { deliveredAt: FieldValue.serverTimestamp() } : {}),
+      certificateStatus: cert,
+      testMode: ctx.testMode,
+      apiKeyId: ctx.apiKeyId,
+      requestId: ctx.requestId,
+      metadata,
+    });
+
+  if (simulate) {
+    await getAdminDb()
+      .collection("mail")
+      .doc(mailId)
+      .update({
+        simulated: true,
+        testMode: true,
+        delivery: {
+          state: "DELIVERED",
+          time: createdAt,
+          info: "sandbox",
+        },
+      })
+      .catch(() => undefined);
+  } else {
+    await enqueuePublicApiSend({ mailId, notificationId: publicId }).catch((e) =>
+      console.warn("public-api enqueue send", e instanceof Error ? e.message : e)
+    );
+  }
+
+  await emitPublicApiEvent({
+    type: simulate ? "notification.delivered" : "notification.queued",
+    orgId: ctx.orgId,
+    environment: ctx.environment,
+    data: {
+      notification_id: publicId,
+      reference,
+      status,
+    },
+  }).catch((e) => console.warn("public-api queued event", e instanceof Error ? e.message : e));
+
+  const body = {
+    id: publicId,
+    status,
+    channel: input.channel,
+    recipient: input.channel === "whatsapp" ? { phone: maskPhone(phone) } : { email: maskEmail(email) },
+    reference,
+    created_at: createdAt,
+    ...(ctx.testMode ? { test_mode: true } : {}),
+  };
+  return { httpStatus: 201, body };
+}
+
+export async function getPublicNotification(ctx: PublicApiAuthContext, id: string) {
+  const snap = await getAdminDb().collection(COLLECTIONS.apiNotifications).doc(id).get();
+  if (!snap.exists) throw notFound("notification_not_found", "Notification not found.");
+  const data = snap.data()!;
+  assertTenant(String(data.orgId || ""), ctx.orgId);
+  if (Boolean(data.testMode) !== ctx.testMode) throw notFound("notification_not_found", "Notification not found.");
+  return serializeNotification(data, snap.id);
+}
+
+export async function listPublicNotifications(
+  ctx: PublicApiAuthContext,
+  query: Record<string, string | undefined>
+) {
+  const parsed = listNotificationsQuerySchema.safeParse(query);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw invalidRequest("invalid_request", issue?.message || "Invalid query.", issue?.path.join(".") || undefined);
+  }
+  const q = parsed.data;
+  const limit = q.limit ?? 50;
+  const db = getAdminDb();
+  let ref: FirebaseFirestore.Query = db
+    .collection(COLLECTIONS.apiNotifications)
+    .where("orgId", "==", ctx.orgId)
+    .where("testMode", "==", ctx.testMode);
+
+  if (q.recipient) {
+    const token = q.recipient.includes("@") ? q.recipient.trim().toLowerCase() : phoneDigits(q.recipient) || q.recipient.trim();
+    ref = ref.where("recipientSearch", "array-contains", token);
+  } else if (q.reference) {
+    ref = ref.where("reference", "==", q.reference);
+  } else if (q.status) {
+    ref = ref.where("status", "==", q.status);
+  } else if (q.channel) {
+    ref = ref.where("channel", "==", q.channel);
+  }
+
+  ref = ref.orderBy("createdAt", "desc").orderBy("__name__", "desc").limit(limit + 1);
+
+  const cursor = decodeCursor(q.cursor);
+  if (cursor) {
+    const cursorSnap = await db.collection(COLLECTIONS.apiNotifications).doc(cursor.id).get();
+    if (cursorSnap.exists && cursorSnap.data()?.orgId === ctx.orgId) {
+      ref = ref.startAfter(cursorSnap);
+    }
+  }
+
+  const snap = await ref.get();
+  let docs = snap.docs;
+  if (q.status && q.recipient) docs = docs.filter((d) => d.data().status === q.status);
+  if (q.channel && (q.recipient || q.reference || q.status)) {
+    docs = docs.filter((d) => d.data().channel === q.channel);
+  }
+  if (q.reference && q.recipient) docs = docs.filter((d) => d.data().reference === q.reference);
+  if (q.created_from || q.created_to) {
+    const from = q.created_from ? Date.parse(q.created_from) : 0;
+    const to = q.created_to ? Date.parse(q.created_to) : Number.MAX_SAFE_INTEGER;
+    docs = docs.filter((d) => {
+      const iso = toIso(d.data().createdAt);
+      const ms = iso ? Date.parse(iso) : 0;
+      return ms >= from && ms <= to;
+    });
+  }
+  const page = docs.slice(0, limit);
+  const hasMore = docs.length > limit;
+  const last = page[page.length - 1];
+  const nextCursor =
+    hasMore && last
+      ? encodeCursor({
+          createdAtMs: Date.parse(toIso(last.data().createdAt) || "") || 0,
+          id: last.id,
+        })
+      : null;
+
+  return {
+    data: page.map((d) => serializeNotification(d.data(), d.id)),
+    has_more: Boolean(nextCursor),
+    cursor: nextCursor,
+  };
+}
+
+export async function getPublicCertificate(ctx: PublicApiAuthContext, id: string) {
+  const snap = await getAdminDb().collection(COLLECTIONS.apiNotifications).doc(id).get();
+  if (!snap.exists) throw notFound("notification_not_found", "Notification not found.");
+  const data = snap.data()!;
+  assertTenant(String(data.orgId || ""), ctx.orgId);
+  if (Boolean(data.testMode) !== ctx.testMode) throw notFound("notification_not_found", "Notification not found.");
+
+  if (data.testMode === true && data.certificateStatus === "sandbox") {
+    return {
+      status: "processing" as const,
+      test_mode: true,
+      message:
+        "Sandbox notifications do not generate a production constancia unless the recipient is on the allowlist and a real send occurred.",
+    };
+  }
+
+  const mailId = String(data.mailId || "");
+  const mailSnap = await getAdminDb().collection("mail").doc(mailId).get();
+  const mail = mailSnap.data() || {};
+  const cert = certificateStatusFromMail({
+    evidenceSealed: mail.evidenceSealed,
+    evidenceSnapshotHash: mail.evidenceSnapshotHash,
+    constanciaPath: mail.constanciaEnvioPath,
+    testMode: data.testMode === true,
+    simulated: mail.simulated === true,
+    realSend: mail.simulated !== true,
+  });
+  if (cert !== "ready") {
+    return { status: "processing" as const, ...(data.testMode ? { test_mode: true } : {}) };
+  }
+
+  const path = constanciaEnvioStoragePath(mailId);
+  const expires = new Date(Date.now() + 15 * 60 * 1000);
+  try {
+    const [url] = await getAdminBucket()
+      .file(path)
+      .getSignedUrl({
+        version: "v4",
+        action: "read",
+        expires,
+      });
+    return {
+      status: "ready" as const,
+      kind: "constancia_envio",
+      download_url: url,
+      expires_at: expires.toISOString(),
+      ...(data.testMode ? { test_mode: true } : {}),
+    };
+  } catch (e) {
+    console.warn("public-api signed url", e instanceof Error ? e.message : e);
+    return { status: "processing" as const };
+  }
+}
+
+export { normalizeNotificationStatus };

--- a/src/lib/public-api/public-api.test.ts
+++ b/src/lib/public-api/public-api.test.ts
@@ -1,0 +1,197 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { hashApiKey, hmacSha256Hex, sha256Hex, timingSafeEqualHex } from "./crypto";
+import { parseApiKey, generateApiKeySecret } from "./api-key-format";
+import { errorBody, forbidden, PublicApiError, unauthorized } from "./errors";
+import { isBatchPublicId, isNotificationPublicId, newBatchId, newNotificationId, newRequestId } from "./ids";
+import { canonicalJson, requestFingerprint } from "./idempotency-hash";
+import { maskEmail, maskPhone } from "./mask";
+import { mergeStatus, normalizeBatchStatus, normalizeNotificationStatus } from "./status";
+import { staticWebhookUrlCheck, isBlockedIp } from "./ssrf";
+import {
+  createNotificationSchema,
+  isValidEmail,
+  isValidIdempotencyKey,
+  sanitizeMetadata,
+  sanitizeVariables,
+} from "./validation";
+import { isSandboxRecipientAllowed, mergeAllowlist } from "./sandbox";
+import { signWebhookPayload, verifyWebhookSignature } from "./webhook-signature";
+import { nextWebhookDelaySeconds, shouldRetryWebhookStatus } from "./webhook-retry";
+import { decodeCursor, encodeCursor } from "./cursor";
+import { hasScope } from "./scopes";
+import { assertTenant } from "./tenant";
+import { toWhatsAppPhone } from "../parse-campaign-csv";
+
+test("API keys: live/test format, never equal to hash", () => {
+  const live = generateApiKeySecret("live");
+  const testKey = generateApiKeySecret("test");
+  assert.match(live.fullKey, /^ntf_live_[A-Za-z0-9]{16,}$/);
+  assert.match(testKey.fullKey, /^ntf_test_[A-Za-z0-9]{16,}$/);
+  assert.equal(parseApiKey(live.fullKey)?.environment, "live");
+  assert.equal(parseApiKey(testKey.fullKey)?.environment, "test");
+  assert.equal(parseApiKey("sk_live_abc"), null);
+  const hashed = hashApiKey(live.fullKey);
+  assert.notEqual(hashed, live.fullKey);
+  assert.equal(hashed.length, 64);
+  assert.equal(hashed.includes(live.fullKey), false);
+});
+
+test("API keys: invalid and revoked-shaped errors", () => {
+  const err = unauthorized("revoked_api_key", "This API key has been revoked.");
+  assert.equal(err.httpStatus, 401);
+  const body = errorBody(err, "req_test");
+  assert.equal(body.error.code, "revoked_api_key");
+  assert.equal(body.error.request_id, "req_test");
+  assert.equal("stack" in body.error, false);
+});
+
+test("tenant isolation helper hides foreign resources as 404", () => {
+  assert.throws(
+    () => assertTenant("org_a", "org_b"),
+    (e: unknown) => e instanceof PublicApiError && e.httpStatus === 404 && e.code === "not_found"
+  );
+  assert.doesNotThrow(() => assertTenant("org_a", "org_a"));
+});
+
+test("scopes: missing scope is denied conceptually", () => {
+  assert.equal(hasScope(["notifications:read"], "notifications:write"), false);
+  assert.equal(hasScope(["notifications:write"], "notifications:write"), true);
+  assert.equal(hasScope(["*"], "batches:write"), true);
+});
+
+test("notification public ids", () => {
+  const live = newNotificationId(false);
+  const sandbox = newNotificationId(true);
+  assert.equal(isNotificationPublicId(live), true);
+  assert.equal(isNotificationPublicId(sandbox), true);
+  assert.equal(sandbox.startsWith("ntf_test_"), true);
+  assert.equal(isNotificationPublicId("mail_abc"), false);
+  assert.equal(isBatchPublicId(newBatchId(false)), true);
+  assert.match(newRequestId(), /^req_/);
+});
+
+test("status normalization from mail/campaign fields", () => {
+  assert.equal(normalizeNotificationStatus({ queued: true }), "queued");
+  assert.equal(normalizeNotificationStatus({ deliveryState: "DELIVERED" }), "sent");
+  assert.equal(normalizeNotificationStatus({ transportStatus: "delivered" }), "delivered");
+  assert.equal(normalizeNotificationStatus({ whatsappDelivered: true }), "delivered");
+  assert.equal(normalizeNotificationStatus({ whatsappRead: true }), "read");
+  assert.equal(normalizeNotificationStatus({ waEstado: "leido" }), "read");
+  assert.equal(normalizeNotificationStatus({ deliveryState: "ERROR" }), "failed");
+  assert.equal(normalizeNotificationStatus({ transportStatus: "bounced" }), "failed");
+  assert.equal(normalizeBatchStatus("enviando"), "processing");
+  assert.equal(normalizeBatchStatus("completada"), "completed");
+  assert.equal(mergeStatus("delivered", "failed"), "delivered");
+  assert.equal(mergeStatus("sent", "read"), "read");
+});
+
+test("validation: phone, email, template injection, metadata", () => {
+  assert.equal(Boolean(toWhatsAppPhone("+5493364123456")), true);
+  assert.equal(toWhatsAppPhone("123"), undefined);
+  assert.equal(isValidEmail("juan@email.com"), true);
+  assert.equal(isValidEmail("not-an-email"), false);
+  const bad = createNotificationSchema.safeParse({
+    channel: "whatsapp",
+    recipient: { phone: "+5493364123456" },
+    createdBy: "attacker",
+    orgId: "other-org",
+  });
+  assert.equal(bad.success, false);
+  const vars = sanitizeVariables({ nombre: "Juan", "<script>": "x", bad: "a".repeat(600) });
+  assert.equal(vars["<script>"], undefined);
+  assert.ok((vars.bad || "").length <= 500);
+  const meta = sanitizeMetadata({ crm_id: "78482", extra: 1 });
+  assert.equal(meta.crm_id, "78482");
+  assert.equal(isValidIdempotencyKey("cobranza-982734"), true);
+});
+
+test("sandbox allowlist matching", () => {
+  const allow = mergeAllowlist({ phones: ["+5493364123456"], emails: ["dev@empresa.com"] });
+  assert.equal(isSandboxRecipientAllowed({ allowlist: allow, phone: "+5493364123456" }), true);
+  assert.equal(isSandboxRecipientAllowed({ allowlist: allow, phone: "+5491111111111" }), false);
+  assert.equal(isSandboxRecipientAllowed({ allowlist: allow, email: "dev@empresa.com" }), true);
+});
+
+test("SSRF: block localhost, private IPs, metadata, require https in live", () => {
+  assert.equal(staticWebhookUrlCheck("http://localhost/hook", { requireHttps: true }).ok, false);
+  assert.equal(staticWebhookUrlCheck("https://127.0.0.1/hook", { requireHttps: true }).ok, false);
+  assert.equal(staticWebhookUrlCheck("https://10.0.0.5/hook", { requireHttps: true }).ok, false);
+  assert.equal(staticWebhookUrlCheck("https://169.254.169.254/latest/meta-data", { requireHttps: true }).ok, false);
+  assert.equal(staticWebhookUrlCheck("https://metadata.google.internal/", { requireHttps: true }).ok, false);
+  assert.equal(staticWebhookUrlCheck("http://example.com/hook", { requireHttps: true }).ok, false);
+  assert.equal(staticWebhookUrlCheck("https://hooks.example.com/notificas", { requireHttps: true }).ok, true);
+  assert.equal(isBlockedIp("192.168.1.1"), true);
+  assert.equal(isBlockedIp("8.8.8.8"), false);
+});
+
+test("webhook signature HMAC and replay window", () => {
+  const secret = "whsec_testsecret";
+  const eventId = "evt_01TEST";
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const rawBody = JSON.stringify({ id: eventId, type: "notification.delivered" });
+  const header = signWebhookPayload(secret, eventId, timestamp, rawBody);
+  assert.equal(verifyWebhookSignature({ secret, eventId, timestamp, rawBody, signatureHeader: header }).ok, true);
+  assert.equal(
+    verifyWebhookSignature({ secret: "whsec_other", eventId, timestamp, rawBody, signatureHeader: header }).ok,
+    false
+  );
+  const oldTs = String(Math.floor(Date.now() / 1000) - 3600);
+  const oldHeader = signWebhookPayload(secret, eventId, oldTs, rawBody);
+  const replay = verifyWebhookSignature({
+    secret,
+    eventId,
+    timestamp: oldTs,
+    rawBody,
+    signatureHeader: oldHeader,
+  });
+  assert.equal(replay.ok, false);
+  if (!replay.ok) assert.equal(replay.code, "timestamp_expired");
+});
+
+test("webhook retries keep the same event and use backoff", () => {
+  assert.equal(nextWebhookDelaySeconds(0), 0);
+  assert.equal(nextWebhookDelaySeconds(1), 60);
+  assert.equal(nextWebhookDelaySeconds(2), 300);
+  assert.equal(nextWebhookDelaySeconds(99), null);
+  assert.equal(shouldRetryWebhookStatus(500, false), true);
+  assert.equal(shouldRetryWebhookStatus(408, false), true);
+  assert.equal(shouldRetryWebhookStatus(200, false), false);
+  assert.equal(shouldRetryWebhookStatus(400, false), false);
+  assert.equal(shouldRetryWebhookStatus(null, true), true);
+});
+
+test("idempotency fingerprint differs when body differs", () => {
+  const a = requestFingerprint({ channel: "whatsapp", reference: "A" });
+  const b = requestFingerprint({ channel: "whatsapp", reference: "B" });
+  const same = requestFingerprint({ reference: "A", channel: "whatsapp" });
+  assert.equal(a, same);
+  assert.notEqual(a, b);
+  assert.equal(canonicalJson({ b: 1, a: 2 }), '{"a":2,"b":1}');
+});
+
+test("mask recipient data in API responses", () => {
+  const phone = maskPhone("+5493364123456");
+  assert.ok(phone);
+  assert.equal(phone.includes("123456"), false);
+  const email = maskEmail("juan@email.com");
+  assert.ok(email);
+  assert.match(email, /^ju\*\*\*@email.com$/);
+});
+
+test("cursor encode/decode", () => {
+  const c = { createdAtMs: 1_700_000_000_000, id: "ntf_01TEST" };
+  assert.deepEqual(decodeCursor(encodeCursor(c)), c);
+  assert.equal(decodeCursor("%%%"), null);
+});
+
+test("timing-safe compare rejects different lengths", () => {
+  assert.equal(timingSafeEqualHex("ab", "abcd"), false);
+  assert.equal(timingSafeEqualHex(hmacSha256Hex("s", "p"), hmacSha256Hex("s", "p")), true);
+});
+
+test("forbidden vs not found for IDOR-style mismatch", () => {
+  const hidden = forbidden("tenant_mismatch", "no");
+  assert.equal(hidden.httpStatus, 403);
+  assert.equal(sha256Hex("secret").includes("secret"), false);
+});

--- a/src/lib/public-api/rate-limit-config.ts
+++ b/src/lib/public-api/rate-limit-config.ts
@@ -1,0 +1,35 @@
+export const RATE_LIMIT_WINDOWS_SECONDS = 60;
+
+export type RateBucket = "general" | "notifications" | "batches";
+
+export type RateLimitConfig = Record<RateBucket, number>;
+
+const DEFAULTS: RateLimitConfig = {
+  general: 120,
+  notifications: 30,
+  batches: 5,
+};
+
+function envInt(name: string, fallback: number): number {
+  const n = Number(process.env[name]);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.floor(n);
+}
+
+export function getRateLimitConfig(): RateLimitConfig {
+  return {
+    general: envInt("PUBLIC_API_RATE_LIMIT_GENERAL", DEFAULTS.general),
+    notifications: envInt("PUBLIC_API_RATE_LIMIT_NOTIFICATIONS", DEFAULTS.notifications),
+    batches: envInt("PUBLIC_API_RATE_LIMIT_BATCHES", DEFAULTS.batches),
+  };
+}
+
+export function windowStartMs(nowMs: number, windowSeconds = RATE_LIMIT_WINDOWS_SECONDS): number {
+  const w = windowSeconds * 1000;
+  return Math.floor(nowMs / w) * w;
+}
+
+export function retryAfterSeconds(nowMs: number, windowSeconds = RATE_LIMIT_WINDOWS_SECONDS): number {
+  const start = windowStartMs(nowMs, windowSeconds);
+  return Math.max(1, Math.ceil((start + windowSeconds * 1000 - nowMs) / 1000));
+}

--- a/src/lib/public-api/rate-limit.ts
+++ b/src/lib/public-api/rate-limit.ts
@@ -1,0 +1,51 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import {
+  getRateLimitConfig,
+  retryAfterSeconds,
+  windowStartMs,
+  type RateBucket,
+} from "@/lib/public-api/rate-limit-config";
+import { rateLimited } from "@/lib/public-api/errors";
+import { COLLECTIONS } from "@/lib/public-api/types";
+
+export async function consumeRateLimit(opts: {
+  apiKeyId: string;
+  orgId: string;
+  bucket: RateBucket;
+  extra?: RateBucket;
+}): Promise<{ retryAfterSeconds?: number }> {
+  const cfg = getRateLimitConfig();
+  const now = Date.now();
+  const start = windowStartMs(now);
+  const db = getAdminDb();
+
+  const buckets: RateBucket[] = opts.extra ? ["general", opts.extra] : [opts.bucket];
+  if (!buckets.includes("general")) buckets.unshift("general");
+
+  for (const bucket of Array.from(new Set(buckets))) {
+    const limit = cfg[bucket];
+    const docId = `${opts.apiKeyId}_${bucket}_${start}`;
+    const ref = db.collection(COLLECTIONS.apiRateLimits).doc(docId);
+    const retry = await db.runTransaction(async (t) => {
+      const snap = await t.get(ref);
+      const count = typeof snap.data()?.count === "number" ? snap.data()!.count : 0;
+      if (count >= limit) return retryAfterSeconds(now);
+      t.set(
+        ref,
+        {
+          apiKeyId: opts.apiKeyId,
+          orgId: opts.orgId,
+          bucket,
+          windowStart: start,
+          count: FieldValue.increment(1),
+          expiresAtMs: start + 2 * 60 * 1000,
+        },
+        { merge: true }
+      );
+      return 0;
+    });
+    if (retry > 0) throw Object.assign(rateLimited(retry), { retryAfterSeconds: retry });
+  }
+  return {};
+}

--- a/src/lib/public-api/sandbox.ts
+++ b/src/lib/public-api/sandbox.ts
@@ -1,0 +1,40 @@
+import { phoneDigits } from "@/lib/parse-campaign-csv";
+
+export type SandboxAllowlist = {
+  phones: string[];
+  emails: string[];
+};
+
+function envList(name: string): string[] {
+  return String(process.env[name] || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function mergeAllowlist(org: SandboxAllowlist | undefined): SandboxAllowlist {
+  const phones = [
+    ...(org?.phones || []),
+    ...envList("PUBLIC_API_SANDBOX_ALLOWLIST_PHONES"),
+  ].map((p) => phoneDigits(p));
+  const emails = [
+    ...(org?.emails || []),
+    ...envList("PUBLIC_API_SANDBOX_ALLOWLIST_EMAILS"),
+  ].map((e) => e.trim().toLowerCase());
+  return {
+    phones: phones.filter(Boolean),
+    emails: emails.filter(Boolean),
+  };
+}
+
+export function isSandboxRecipientAllowed(opts: {
+  allowlist: SandboxAllowlist;
+  phone?: string;
+  email?: string;
+}): boolean {
+  const phone = phoneDigits(opts.phone);
+  const email = (opts.email || "").trim().toLowerCase();
+  if (phone && opts.allowlist.phones.includes(phone)) return true;
+  if (email && opts.allowlist.emails.includes(email)) return true;
+  return false;
+}

--- a/src/lib/public-api/scopes.ts
+++ b/src/lib/public-api/scopes.ts
@@ -1,0 +1,25 @@
+export const PUBLIC_API_SCOPES = [
+  "notifications:read",
+  "notifications:write",
+  "batches:read",
+  "batches:write",
+  "webhooks:read",
+  "webhooks:write",
+] as const;
+
+export type PublicApiScope = (typeof PUBLIC_API_SCOPES)[number];
+
+export const DEFAULT_LIVE_SCOPES: PublicApiScope[] = [
+  "notifications:read",
+  "notifications:write",
+  "batches:read",
+  "batches:write",
+  "webhooks:read",
+  "webhooks:write",
+];
+
+export function hasScope(granted: string[] | undefined, needed: PublicApiScope): boolean {
+  if (!Array.isArray(granted) || granted.length === 0) return true;
+  if (granted.includes("*")) return true;
+  return granted.includes(needed);
+}

--- a/src/lib/public-api/sdk.test.ts
+++ b/src/lib/public-api/sdk.test.ts
@@ -1,0 +1,181 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createContext, runInContext } from "node:vm";
+
+type NotificasSdk = {
+  version: string;
+  create: (opts: Record<string, unknown>) => {
+    sendCertifiedNotification: (input: Record<string, unknown>) => Promise<unknown>;
+    getNotification: (id: string) => Promise<unknown>;
+    listNotifications: (q?: Record<string, unknown>) => Promise<unknown>;
+    getCertificate: (id: string) => Promise<unknown>;
+    me: () => Promise<unknown>;
+  };
+  embed: (target: unknown, opts?: Record<string, unknown>) => { destroy: () => void };
+  _assertBrowserKeySafe: (opts: Record<string, unknown>) => void;
+  _parseVariables: (raw: unknown) => Record<string, string>;
+  _resolveUrl: (opts: Record<string, unknown>, path: string) => string;
+  _isLiveKey: (key: string) => boolean;
+};
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+  };
+}
+
+function loadSdk(opts?: { browser?: boolean; fetchImpl?: (...args: unknown[]) => Promise<unknown> }) {
+  const source = readFileSync(resolve(process.cwd(), "public/sdk/v1/notificas.js"), "utf8");
+  const fetchImpl =
+    opts?.fetchImpl ??
+    (async () => jsonResponse(200, { id: "ntf_x", status: "queued" }));
+
+  const sandbox: Record<string, unknown> = {
+    fetch: fetchImpl,
+    console,
+    setTimeout,
+    clearTimeout,
+    Date,
+    URL,
+    URLSearchParams,
+    Headers,
+    AbortController,
+    crypto: globalThis.crypto,
+  };
+
+  if (opts?.browser) {
+    sandbox.window = sandbox;
+    sandbox.document = {
+      readyState: "complete",
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      addEventListener: () => undefined,
+      createElement: () => ({
+        setAttribute: () => undefined,
+        appendChild: () => undefined,
+        addEventListener: () => undefined,
+        style: {},
+        className: "",
+        innerHTML: "",
+        textContent: "",
+      }),
+      head: { appendChild: () => undefined },
+      body: { appendChild: () => undefined },
+    };
+  }
+
+  const ctx = createContext(sandbox);
+  runInContext(source, ctx);
+  return { sdk: sandbox.Notificas as NotificasSdk, fetchImpl };
+}
+
+test("SDK: version and URL helpers", () => {
+  const { sdk } = loadSdk();
+  assert.equal(sdk.version, "1.0.0");
+  assert.equal(sdk._isLiveKey("ntf_live_abc"), true);
+  assert.equal(sdk._isLiveKey("ntf_test_abc"), false);
+  assert.equal(
+    sdk._resolveUrl({ proxyUrl: "https://acme.test/api/notificas" }, "/api/v1/notifications"),
+    "https://acme.test/api/notificas/notifications"
+  );
+  assert.equal(
+    sdk._resolveUrl({ proxyUrl: "https://acme.test/api/notificas" }, "/api/v1/me"),
+    "https://acme.test/api/notificas/me"
+  );
+  assert.equal(
+    sdk._resolveUrl(
+      { proxyUrl: "https://acme.test", proxyMapsFullPath: true },
+      "/api/v1/notifications"
+    ),
+    "https://acme.test/api/v1/notifications"
+  );
+  assert.equal(
+    sdk._resolveUrl({ baseUrl: "https://notificas.com.ar" }, "/api/v1/notifications"),
+    "https://notificas.com.ar/api/v1/notifications"
+  );
+  const fromJson = sdk._parseVariables('{"nombre":"Ana"}');
+  assert.equal(fromJson.nombre, "Ana");
+  const fromPairs = sdk._parseVariables("nombre=Ana\nmonto=100");
+  assert.equal(fromPairs.nombre, "Ana");
+  assert.equal(fromPairs.monto, "100");
+});
+
+test("SDK: blocks ntf_live_ in the browser without proxy", () => {
+  const { sdk } = loadSdk({ browser: true });
+  assert.throws(
+    () =>
+      sdk._assertBrowserKeySafe({
+        apiKey: "ntf_live_secret",
+        proxyUrl: "",
+        allowBrowserKey: false,
+      }),
+    /ntf_live_/
+  );
+  assert.doesNotThrow(() =>
+    sdk._assertBrowserKeySafe({
+      apiKey: "ntf_test_secret",
+      proxyUrl: "",
+      allowBrowserKey: false,
+    })
+  );
+  assert.doesNotThrow(() =>
+    sdk._assertBrowserKeySafe({
+      apiKey: "",
+      proxyUrl: "/api/notificas",
+      allowBrowserKey: false,
+    })
+  );
+});
+
+test("SDK: proxy POST does not send the API key from the browser", async () => {
+  const calls: Array<[string, { headers: Record<string, string>; body?: string }]> = [];
+  const fetchImpl = async (url: string, init: { headers: Record<string, string>; body?: string }) => {
+    calls.push([url, init]);
+    return jsonResponse(200, { id: "ntf_x", status: "queued" });
+  };
+  const { sdk } = loadSdk({ fetchImpl: fetchImpl as never });
+  const client = sdk.create({ proxyUrl: "https://acme.test/api/notificas" });
+  await client.sendCertifiedNotification({
+    channel: "email",
+    recipient: { email: "ana@acme.test" },
+    subject: "Aviso",
+    body: "<p>Hola</p>",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "https://acme.test/api/notificas/notifications");
+  assert.equal(calls[0][1].headers.Authorization, undefined);
+  assert.equal(JSON.parse(String(calls[0][1].body)).channel, "email");
+  assert.match(String(calls[0][1].headers["Idempotency-Key"] || ""), /./);
+});
+
+test("SDK: test key talks to Notificas with Bearer", async () => {
+  const calls: Array<[string, { headers: Record<string, string> }]> = [];
+  const fetchImpl = async (url: string, init: { headers: Record<string, string> }) => {
+    calls.push([url, init]);
+    return jsonResponse(200, { account: { environment: "test" } });
+  };
+  const { sdk } = loadSdk({ fetchImpl: fetchImpl as never });
+  const client = sdk.create({
+    apiKey: "ntf_test_abc",
+    baseUrl: "https://notificas.com.ar",
+  });
+  await client.me();
+  assert.equal(calls[0][0], "https://notificas.com.ar/api/v1/me");
+  assert.equal(calls[0][1].headers.Authorization, "Bearer ntf_test_abc");
+});
+
+test("SDK: propagates API errors", async () => {
+  const fetchImpl = async () =>
+    jsonResponse(401, { error: { code: "unauthorized", message: "API key inválida." } });
+  const { sdk } = loadSdk({ fetchImpl: fetchImpl as never });
+  const client = sdk.create({ proxyUrl: "/api/notificas" });
+  await assert.rejects(client.me(), (err: unknown) => {
+    const e = err as { code?: string; status?: number };
+    return e.code === "unauthorized" && e.status === 401;
+  });
+});

--- a/src/lib/public-api/send-worker.ts
+++ b/src/lib/public-api/send-worker.ts
@@ -1,0 +1,66 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { invokeSendEmail } from "@/lib/send-mail-via-cf";
+import { sealEvidenceSnapshot } from "@/lib/evidence-snapshot";
+import { computeContentHash } from "@/lib/certification";
+import { certificarEnvio, certifyWhatsAppPayloadIfNeeded } from "@/lib/certification-polygon";
+import { syncPublicApiNotificationFromMail } from "@/lib/public-api/status-sync";
+import { COLLECTIONS } from "@/lib/public-api/types";
+
+async function certifyInBackground(docId: string): Promise<void> {
+  try {
+    const snap = await getAdminDb().collection("mail").doc(docId).get();
+    const mailData = snap.data();
+    if (!mailData) return;
+    const toEmail = Array.isArray(mailData.to) ? mailData.to[0] : mailData.recipientEmail || mailData.to || "";
+    const fromUserId = mailData.createdBy || mailData.senderName || "app";
+    const contentHash = await computeContentHash(mailData.message?.contentText || "");
+    const polygonTxHash = await Promise.race([
+      certificarEnvio(docId, fromUserId, toEmail, contentHash),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Timeout certificación Polygon (>40s)")), 40_000)),
+    ]);
+    await getAdminDb().collection("mail").doc(docId).update({
+      "polygonCertifications.send": polygonTxHash,
+      "polygonCertifications.contentHash": contentHash,
+      "polygonCertifications.updatedAt": new Date(),
+    });
+    await certifyWhatsAppPayloadIfNeeded(docId).catch(() => undefined);
+  } catch (err: unknown) {
+    console.error("public-api certify", err instanceof Error ? err.message : err);
+  }
+}
+
+export async function processPublicApiSend(mailId: string, notificationId: string): Promise<void> {
+  const db = getAdminDb();
+  const mailSnap = await db.collection("mail").doc(mailId).get();
+  if (!mailSnap.exists) return;
+  const mail = mailSnap.data()!;
+  if (mail.publicApiId && mail.publicApiId !== notificationId) return;
+  if (mail.simulated === true) return;
+
+  await db.collection(COLLECTIONS.apiNotifications).doc(notificationId).update({
+    status: "processing",
+    updatedAt: FieldValue.serverTimestamp(),
+  }).catch(() => undefined);
+
+  const result = await invokeSendEmail(mailId);
+  if (!result.ok && !result.skipped) {
+    await db.collection("mail").doc(mailId).update({
+      delivery: { state: "ERROR", time: new Date().toISOString(), error: result.error || "send_failed" },
+    }).catch(() => undefined);
+    await syncPublicApiNotificationFromMail(mailId, "failed");
+    return;
+  }
+
+  if (mail.apiChannel === "whatsapp" || mail.waOnly) {
+    const fresh = await db.collection("mail").doc(mailId).get();
+    const wamid = fresh.data()?.whatsappMessageId || fresh.data()?.tracking?.whatsappMessageId;
+    if (wamid) {
+      await db.collection("whatsapp_ids").doc(String(wamid)).set({ mailDocId: mailId }, { merge: true });
+    }
+  }
+
+  void certifyInBackground(mailId);
+  void sealEvidenceSnapshot(mailId).catch((e) => console.warn("public-api snapshot", e instanceof Error ? e.message : e));
+  await syncPublicApiNotificationFromMail(mailId, "sent");
+}

--- a/src/lib/public-api/ssrf.ts
+++ b/src/lib/public-api/ssrf.ts
@@ -1,0 +1,126 @@
+import { lookup } from "dns/promises";
+import { isIP } from "net";
+
+const PRIVATE_HOSTS = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "metadata.google.internal",
+  "metadata",
+  "internal",
+]);
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split(".").map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+  return ((parts[0] << 24) >>> 0) + (parts[1] << 16) + (parts[2] << 8) + parts[3];
+}
+
+function ipv4InCidr(ip: string, cidr: string): boolean {
+  const [base, bitsStr] = cidr.split("/");
+  const ipN = ipv4ToInt(ip);
+  const baseN = ipv4ToInt(base);
+  const bits = Number(bitsStr);
+  if (ipN == null || baseN == null || !Number.isInteger(bits)) return false;
+  const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+  return (ipN & mask) === (baseN & mask);
+}
+
+const IPV4_BLOCKED = [
+  "0.0.0.0/8",
+  "10.0.0.0/8",
+  "127.0.0.0/8",
+  "169.254.0.0/16",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+  "100.64.0.0/10",
+  "192.0.0.0/24",
+  "192.0.2.0/24",
+  "198.18.0.0/15",
+  "198.51.100.0/24",
+  "203.0.113.0/24",
+  "224.0.0.0/4",
+  "240.0.0.0/4",
+];
+
+function isBlockedIPv4(ip: string): boolean {
+  return IPV4_BLOCKED.some((c) => ipv4InCidr(ip, c));
+}
+
+function isBlockedIPv6(ip: string): boolean {
+  const n = ip.toLowerCase();
+  if (n === "::1" || n === "::") return true;
+  if (n.startsWith("fe80:") || n.startsWith("fc") || n.startsWith("fd")) return true;
+  if (n.startsWith("::ffff:")) {
+    const v4 = n.slice("::ffff:".length);
+    if (isIP(v4) === 4) return isBlockedIPv4(v4);
+  }
+  return false;
+}
+
+export function isBlockedIp(ip: string): boolean {
+  const version = isIP(ip);
+  if (version === 4) return isBlockedIPv4(ip);
+  if (version === 6) return isBlockedIPv6(ip);
+  return true;
+}
+
+export type SsrfCheckResult = { ok: true; hostname: string; ips: string[] } | { ok: false; code: string; message: string };
+
+export function parseWebhookUrl(raw: string): URL | null {
+  try {
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rechaza URLs inseguras (SSRF): localhost, IPs privadas, metadata cloud, no-HTTPS en live.
+ */
+export function staticWebhookUrlCheck(raw: string, opts: { requireHttps: boolean }): SsrfCheckResult {
+  const url = parseWebhookUrl(raw);
+  if (!url) return { ok: false, code: "invalid_url", message: "The webhook URL is invalid." };
+  if (url.username || url.password) {
+    return { ok: false, code: "invalid_url", message: "The webhook URL must not include credentials." };
+  }
+  if (opts.requireHttps && url.protocol !== "https:") {
+    return { ok: false, code: "insecure_url", message: "Webhook URLs must use HTTPS." };
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return { ok: false, code: "invalid_url", message: "Webhook URLs must use HTTP or HTTPS." };
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (!hostname) return { ok: false, code: "invalid_url", message: "The webhook URL is invalid." };
+  if (PRIVATE_HOSTS.has(hostname) || hostname.endsWith(".internal") || hostname.endsWith(".localhost")) {
+    return { ok: false, code: "blocked_host", message: "That host is not allowed." };
+  }
+  if (hostname === "169.254.169.254" || hostname === "metadata.google.internal") {
+    return { ok: false, code: "blocked_host", message: "That host is not allowed." };
+  }
+  const ipVersion = isIP(hostname);
+  if (ipVersion && isBlockedIp(hostname)) {
+    return { ok: false, code: "blocked_ip", message: "Private or reserved IP addresses are not allowed." };
+  }
+  return { ok: true, hostname, ips: ipVersion ? [hostname] : [] };
+}
+
+export async function resolveAndValidateWebhookUrl(
+  raw: string,
+  opts: { requireHttps: boolean }
+): Promise<SsrfCheckResult> {
+  const staticCheck = staticWebhookUrlCheck(raw, opts);
+  if (!staticCheck.ok) return staticCheck;
+  if (staticCheck.ips.length > 0) return staticCheck;
+
+  try {
+    const records = await lookup(staticCheck.hostname, { all: true });
+    const ips = records.map((r) => r.address);
+    if (ips.length === 0) return { ok: false, code: "unresolvable_host", message: "The webhook host could not be resolved." };
+    if (ips.some(isBlockedIp)) {
+      return { ok: false, code: "blocked_ip", message: "The webhook host resolves to a private or reserved address." };
+    }
+    return { ok: true, hostname: staticCheck.hostname, ips };
+  } catch {
+    return { ok: false, code: "unresolvable_host", message: "The webhook host could not be resolved." };
+  }
+}

--- a/src/lib/public-api/status-sync.ts
+++ b/src/lib/public-api/status-sync.ts
@@ -1,0 +1,182 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { emitPublicApiEvent } from "@/lib/public-api/webhooks";
+import {
+  certificateStatusFromMail,
+  mergeStatus,
+  normalizeNotificationStatus,
+  type PublicNotificationStatus,
+} from "@/lib/public-api/status";
+import { COLLECTIONS } from "@/lib/public-api/types";
+import type { WebhookEventType } from "@/lib/public-api/validation";
+
+function eventTypeForStatus(status: PublicNotificationStatus): WebhookEventType | null {
+  switch (status) {
+    case "queued":
+      return "notification.queued";
+    case "sent":
+      return "notification.sent";
+    case "delivered":
+      return "notification.delivered";
+    case "read":
+      return "notification.read";
+    case "failed":
+      return "notification.failed";
+    default:
+      return null;
+  }
+}
+
+function tsNow() {
+  return FieldValue.serverTimestamp();
+}
+
+function timestampField(status: PublicNotificationStatus): string | null {
+  switch (status) {
+    case "sent":
+      return "sentAt";
+    case "delivered":
+      return "deliveredAt";
+    case "read":
+      return "readAt";
+    case "failed":
+      return "failedAt";
+    default:
+      return null;
+  }
+}
+
+export async function registerPublicApiNotification(params: {
+  id: string;
+  orgId: string;
+  mailId: string;
+  channel: "whatsapp" | "email";
+  batchId?: string;
+  testMode: boolean;
+  apiKeyId?: string;
+  reference?: string | null;
+  recipientPhone?: string;
+  recipientEmail?: string;
+  recipientName?: string;
+}): Promise<void> {
+  const ref = getAdminDb().collection(COLLECTIONS.apiNotifications).doc(params.id);
+  const existing = await ref.get();
+  if (existing.exists) return;
+  await ref.set({
+    id: params.id,
+    orgId: params.orgId,
+    mailId: params.mailId,
+    batchId: params.batchId || null,
+    channel: params.channel,
+    status: "queued",
+    reference: params.reference || null,
+    recipientPhone: params.recipientPhone || null,
+    recipientEmail: params.recipientEmail || null,
+    recipientName: params.recipientName || null,
+    createdAt: FieldValue.serverTimestamp(),
+    certificateStatus: params.testMode ? "sandbox" : "processing",
+    testMode: params.testMode,
+    apiKeyId: params.apiKeyId || null,
+  });
+}
+
+export async function syncPublicApiNotificationFromMail(
+  mailId: string,
+  hint?: PublicNotificationStatus
+): Promise<void> {
+  if (!mailId) return;
+  const db = getAdminDb();
+  const mailSnap = await db.collection("mail").doc(mailId).get();
+  if (!mailSnap.exists) return;
+  const mail = mailSnap.data()!;
+  const publicId = String(mail.publicApiId || "");
+  if (!publicId) return;
+
+  const nRef = db.collection(COLLECTIONS.apiNotifications).doc(publicId);
+  const nSnap = await nRef.get();
+  if (!nSnap.exists) return;
+  const current = nSnap.data()!;
+  if (String(current.orgId || "") !== String(mail.orgId || current.orgId || "")) return;
+
+  const next = mergeStatus(
+    current.status as PublicNotificationStatus | undefined,
+    hint ||
+      normalizeNotificationStatus({
+        deliveryState: mail.delivery?.state,
+        transportStatus: mail.transport?.status,
+        whatsappDelivered: mail.tracking?.whatsappDelivered,
+        whatsappRead: mail.tracking?.whatsappRead,
+        readConfirmed: mail.tracking?.readConfirmed,
+        readerOpened: mail.tracking?.opened,
+        simulated: mail.simulated,
+      })
+  );
+
+  const cert = certificateStatusFromMail({
+    evidenceSealed: mail.evidenceSealed,
+    evidenceSnapshotHash: mail.evidenceSnapshotHash,
+    testMode: current.testMode === true,
+    simulated: mail.simulated === true,
+    realSend: mail.simulated !== true,
+  });
+
+  const patch: Record<string, unknown> = {
+    status: next,
+    certificateStatus: cert,
+    updatedAt: tsNow(),
+  };
+  const tf = timestampField(next);
+  if (tf && !current[tf]) patch[tf] = tsNow();
+
+  await nRef.update(patch);
+
+  if (next !== current.status) {
+    const type = eventTypeForStatus(next);
+    if (type) {
+      await emitPublicApiEvent({
+        type,
+        orgId: String(current.orgId),
+        environment: current.testMode === true ? "test" : "live",
+        data: {
+          notification_id: publicId,
+          reference: current.reference || null,
+          status: next,
+        },
+      }).catch((e) => console.warn("public-api event", e instanceof Error ? e.message : e));
+    }
+  }
+
+  if (cert === "ready" && current.certificateStatus !== "ready") {
+    await emitPublicApiEvent({
+      type: "notification.certificate_ready",
+      orgId: String(current.orgId),
+      environment: current.testMode === true ? "test" : "live",
+      data: {
+        notification_id: publicId,
+        reference: current.reference || null,
+        status: next,
+      },
+    }).catch((e) => console.warn("public-api cert event", e instanceof Error ? e.message : e));
+  }
+}
+
+export async function emitBatchCompletedIfApi(campaignId: string): Promise<void> {
+  const db = getAdminDb();
+  const camp = await db.collection("campaigns").doc(campaignId).get();
+  if (!camp.exists) return;
+  const data = camp.data()!;
+  const batchId = String(data.publicApiBatchId || "");
+  if (!batchId) return;
+  const already = data.publicApiBatchCompletedEvent === true;
+  if (already) return;
+  await camp.ref.update({ publicApiBatchCompletedEvent: true }).catch(() => undefined);
+  await emitPublicApiEvent({
+    type: "batch.completed",
+    orgId: String(data.orgId || ""),
+    environment: data.publicApiTestMode === true ? "test" : "live",
+    data: {
+      batch_id: batchId,
+      status: "completed",
+    },
+  }).catch((e) => console.warn("public-api batch event", e instanceof Error ? e.message : e));
+}

--- a/src/lib/public-api/status.ts
+++ b/src/lib/public-api/status.ts
@@ -1,0 +1,143 @@
+export const PUBLIC_NOTIFICATION_STATUSES = [
+  "queued",
+  "processing",
+  "sent",
+  "delivered",
+  "read",
+  "failed",
+] as const;
+
+export type PublicNotificationStatus = (typeof PUBLIC_NOTIFICATION_STATUSES)[number];
+
+export const PUBLIC_CERTIFICATE_STATUSES = ["processing", "ready", "sandbox", "unavailable"] as const;
+export type PublicCertificateStatus = (typeof PUBLIC_CERTIFICATE_STATUSES)[number];
+
+export const PUBLIC_BATCH_STATUSES = ["queued", "processing", "completed", "paused", "cancelled", "failed"] as const;
+export type PublicBatchStatus = (typeof PUBLIC_BATCH_STATUSES)[number];
+
+const RANK: Record<PublicNotificationStatus, number> = {
+  queued: 0,
+  processing: 1,
+  sent: 2,
+  delivered: 3,
+  read: 4,
+  failed: 5,
+};
+
+export function statusRank(status: PublicNotificationStatus): number {
+  return RANK[status] ?? 0;
+}
+
+/** Un failed no debe pisar un delivered/read ya registrado, salvo que el canal informe fallo real de envío. */
+export function mergeStatus(
+  current: PublicNotificationStatus | undefined,
+  incoming: PublicNotificationStatus
+): PublicNotificationStatus {
+  if (!current) return incoming;
+  if (incoming === "failed") {
+    if (current === "delivered" || current === "read") return current;
+    return "failed";
+  }
+  if (current === "failed") return incoming;
+  return statusRank(incoming) >= statusRank(current) ? incoming : current;
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : v == null ? "" : String(v);
+}
+
+/**
+ * Capa de normalización sobre los estados reales de `mail` / `campaign_messages`.
+ * No inventa hechos: "sent" = aceptado por el proveedor; "delivered"/"read" = lo que
+ * reportó Meta o el transporte de correo / apertura del lector.
+ */
+export function normalizeNotificationStatus(input: {
+  deliveryState?: unknown;
+  transportStatus?: unknown;
+  whatsappDelivered?: unknown;
+  whatsappRead?: unknown;
+  readConfirmed?: unknown;
+  readerOpened?: unknown;
+  campaignEstado?: unknown;
+  waEstado?: unknown;
+  emailEstado?: unknown;
+  simulated?: unknown;
+  queued?: boolean;
+}): PublicNotificationStatus {
+  const delivery = str(input.deliveryState).toUpperCase();
+  const transport = str(input.transportStatus).toLowerCase();
+  const camp = str(input.campaignEstado).toLowerCase();
+  const wa = str(input.waEstado).toLowerCase();
+  const email = str(input.emailEstado).toLowerCase();
+
+  if (
+    delivery === "ERROR" ||
+    camp === "error" ||
+    wa === "error" ||
+    email === "error" ||
+    transport === "bounced" ||
+    transport === "failed" ||
+    transport === "suppressed"
+  ) {
+    return "failed";
+  }
+
+  if (
+    input.whatsappRead === true ||
+    input.readConfirmed === true ||
+    wa === "leido" ||
+    email === "leido" ||
+    camp === "leido"
+  ) {
+    return "read";
+  }
+
+  if (input.whatsappDelivered === true || wa === "entregado" || transport === "delivered") {
+    return "delivered";
+  }
+
+  if (
+    delivery === "DELIVERED" ||
+    camp === "enviado" ||
+    wa === "enviado" ||
+    email === "enviado" ||
+    transport === "sent"
+  ) {
+    return "sent";
+  }
+
+  if (input.queued === false && (delivery || camp === "enviando")) return "processing";
+  return "queued";
+}
+
+export function normalizeBatchStatus(estado: unknown): PublicBatchStatus {
+  switch (String(estado || "").toLowerCase()) {
+    case "enviando":
+      return "processing";
+    case "completada":
+      return "completed";
+    case "pausada":
+      return "paused";
+    case "cancelada":
+      return "cancelled";
+    case "borrador":
+      return "queued";
+    default:
+      return "queued";
+  }
+}
+
+export function certificateStatusFromMail(input: {
+  evidenceSealed?: unknown;
+  evidenceSnapshotHash?: unknown;
+  constanciaPath?: unknown;
+  testMode?: boolean;
+  simulated?: boolean;
+  realSend?: boolean;
+}): PublicCertificateStatus {
+  if (input.testMode && !input.realSend) return "sandbox";
+  if (input.evidenceSealed === true || str(input.evidenceSnapshotHash) || str(input.constanciaPath)) {
+    return "ready";
+  }
+  return "processing";
+}

--- a/src/lib/public-api/tenant.ts
+++ b/src/lib/public-api/tenant.ts
@@ -1,0 +1,8 @@
+import { notFound } from "@/lib/public-api/errors";
+
+/** IDOR/BOLA: un recurso de otro tenant se oculta como 404. */
+export function assertTenant(resourceOrgId: string, ctxOrgId: string): void {
+  if (resourceOrgId !== ctxOrgId) {
+    throw notFound("not_found", "Resource not found.");
+  }
+}

--- a/src/lib/public-api/types.ts
+++ b/src/lib/public-api/types.ts
@@ -1,0 +1,68 @@
+import type { PublicApiScope } from "@/lib/public-api/scopes";
+import type { PublicCertificateStatus, PublicNotificationStatus } from "@/lib/public-api/status";
+
+export type ApiEnvironment = "live" | "test";
+
+export type ApiKeyRecord = {
+  id: string;
+  orgId: string;
+  name: string;
+  prefix: string;
+  keyHash: string;
+  environment: ApiEnvironment;
+  scopes: PublicApiScope[];
+  status: "active" | "revoked";
+  createdAt: unknown;
+  lastUsedAt: unknown | null;
+  createdBy: string;
+};
+
+export type PublicApiAuthContext = {
+  requestId: string;
+  apiKeyId: string;
+  apiKeyPrefix: string;
+  orgId: string;
+  orgName: string;
+  orgCuit: string | null;
+  senderUid: string;
+  senderEmail: string;
+  environment: ApiEnvironment;
+  testMode: boolean;
+  scopes: PublicApiScope[];
+};
+
+export type ApiNotificationRecord = {
+  id: string;
+  orgId: string;
+  mailId: string;
+  campaignId?: string | null;
+  campaignMessageId?: string | null;
+  batchId?: string | null;
+  channel: "whatsapp" | "email";
+  status: PublicNotificationStatus;
+  reference: string | null;
+  recipientPhone?: string;
+  recipientEmail?: string;
+  recipientName?: string;
+  createdAt: unknown;
+  sentAt?: unknown;
+  deliveredAt?: unknown;
+  readAt?: unknown;
+  failedAt?: unknown;
+  certificateStatus: PublicCertificateStatus;
+  testMode: boolean;
+  apiKeyId: string;
+  requestId?: string;
+};
+
+export const COLLECTIONS = {
+  apiKeys: "api_keys",
+  apiNotifications: "api_notifications",
+  apiBatches: "api_batches",
+  apiIdempotency: "api_idempotency",
+  apiAudit: "api_audit_logs",
+  apiRateLimits: "api_rate_limits",
+  webhookEndpoints: "webhook_endpoints",
+  webhookEvents: "webhook_events",
+  webhookDeliveries: "webhook_deliveries",
+} as const;

--- a/src/lib/public-api/validation.ts
+++ b/src/lib/public-api/validation.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+import { toWhatsAppPhone } from "@/lib/parse-campaign-csv";
+import { PUBLIC_NOTIFICATION_STATUSES } from "@/lib/public-api/status";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const TEMPLATE_RE = /^[a-z0-9_]{1,128}$/;
+const ID_SAFE_RE = /^[a-zA-Z0-9_.:-]{1,128}$/;
+
+export const MAX_NOTIFICATION_BODY_BYTES = 64 * 1024;
+export const MAX_BATCH_BODY_BYTES = 1024 * 1024;
+export const MAX_WEBHOOK_BODY_BYTES = 16 * 1024;
+export const MAX_BATCH_RECIPIENTS = 5000;
+export const MAX_METADATA_KEYS = 20;
+export const MAX_VARIABLES = 20;
+
+const metadataSchema = z
+  .record(z.string().max(40), z.union([z.string().max(200), z.number(), z.boolean()]))
+  .optional()
+  .refine((v) => !v || Object.keys(v).length <= MAX_METADATA_KEYS, {
+    message: `metadata cannot have more than ${MAX_METADATA_KEYS} keys`,
+  });
+
+const variablesSchema = z
+  .record(z.string().max(40), z.string().max(500))
+  .optional()
+  .refine((v) => !v || Object.keys(v).length <= MAX_VARIABLES, {
+    message: `variables cannot have more than ${MAX_VARIABLES} keys`,
+  });
+
+const recipientSchema = z
+  .object({
+    name: z.string().trim().min(1).max(120).optional(),
+    phone: z.string().trim().max(32).optional(),
+    email: z.string().trim().max(254).optional(),
+    document: z.string().trim().max(20).optional(),
+  })
+  .strict();
+
+export const createNotificationSchema = z
+  .object({
+    channel: z.enum(["whatsapp", "email"]),
+    recipient: recipientSchema,
+    template: z.string().trim().min(1).max(128).optional(),
+    variables: variablesSchema,
+    subject: z.string().trim().min(1).max(300).optional(),
+    body: z.string().trim().min(1).max(20000).optional(),
+    reference: z.string().trim().max(128).optional(),
+    metadata: metadataSchema,
+  })
+  .strict();
+
+export type CreateNotificationInput = z.infer<typeof createNotificationSchema>;
+
+const batchRecipientSchema = z
+  .object({
+    name: z.string().trim().min(1).max(120).optional(),
+    phone: z.string().trim().max(32).optional(),
+    email: z.string().trim().max(254).optional(),
+    document: z.string().trim().max(20).optional(),
+    variables: variablesSchema,
+    reference: z.string().trim().max(128).optional(),
+    metadata: metadataSchema,
+  })
+  .strict();
+
+export const createBatchSchema = z
+  .object({
+    channel: z.enum(["whatsapp", "email"]),
+    template: z.string().trim().min(1).max(128).optional(),
+    subject: z.string().trim().min(1).max(300).optional(),
+    body: z.string().trim().max(20000).optional(),
+    reference: z.string().trim().max(128).optional(),
+    metadata: metadataSchema,
+    recipients: z.array(batchRecipientSchema).min(1).max(MAX_BATCH_RECIPIENTS),
+  })
+  .strict();
+
+export type CreateBatchInput = z.infer<typeof createBatchSchema>;
+
+export const WEBHOOK_EVENT_TYPES = [
+  "notification.queued",
+  "notification.sent",
+  "notification.delivered",
+  "notification.read",
+  "notification.failed",
+  "notification.certificate_ready",
+  "batch.completed",
+] as const;
+
+export type WebhookEventType = (typeof WEBHOOK_EVENT_TYPES)[number];
+
+export const createWebhookEndpointSchema = z
+  .object({
+    url: z.string().trim().url().max(2048),
+    events: z.array(z.enum(WEBHOOK_EVENT_TYPES)).min(1).max(WEBHOOK_EVENT_TYPES.length),
+    description: z.string().trim().max(200).optional(),
+  })
+  .strict();
+
+export const patchWebhookEndpointSchema = z
+  .object({
+    url: z.string().trim().url().max(2048).optional(),
+    events: z.array(z.enum(WEBHOOK_EVENT_TYPES)).min(1).max(WEBHOOK_EVENT_TYPES.length).optional(),
+    enabled: z.boolean().optional(),
+    description: z.string().trim().max(200).optional(),
+  })
+  .strict();
+
+export const listNotificationsQuerySchema = z.object({
+  status: z.enum(PUBLIC_NOTIFICATION_STATUSES).optional(),
+  channel: z.enum(["whatsapp", "email"]).optional(),
+  reference: z.string().trim().max(128).optional(),
+  created_from: z.string().datetime({ offset: true }).optional(),
+  created_to: z.string().datetime({ offset: true }).optional(),
+  recipient: z.string().trim().max(254).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  cursor: z.string().trim().max(512).optional(),
+});
+
+export function isValidEmail(value: string): boolean {
+  const v = value.trim().toLowerCase();
+  return v.length >= 5 && v.length <= 254 && EMAIL_RE.test(v);
+}
+
+export function isValidTemplateName(value: string): boolean {
+  return TEMPLATE_RE.test(value.trim().toLowerCase());
+}
+
+export function isValidIdempotencyKey(value: string): boolean {
+  return ID_SAFE_RE.test(value) || (value.length >= 1 && value.length <= 256 && /^[\x21-\x7E]+$/.test(value));
+}
+
+export function normalizePhoneOrError(raw: string | undefined): { ok: true; phone: string } | { ok: false } {
+  if (!raw) return { ok: false };
+  const phone = toWhatsAppPhone(raw);
+  if (!phone) return { ok: false };
+  return { ok: true, phone };
+}
+
+export function sanitizeMetadata(
+  input: Record<string, string | number | boolean> | undefined
+): Record<string, string> {
+  if (!input) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(input)) {
+    const key = k.trim().slice(0, 40);
+    if (!key) continue;
+    out[key] = String(v).slice(0, 200);
+  }
+  return out;
+}
+
+export function sanitizeVariables(input: Record<string, string> | undefined): Record<string, string> {
+  if (!input) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(input)) {
+    const key = k.trim().slice(0, 40);
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) continue;
+    out[key] = String(v ?? "").replace(/[\u0000-\u001F]/g, "").slice(0, 500);
+  }
+  return out;
+}

--- a/src/lib/public-api/webhook-dispatch.ts
+++ b/src/lib/public-api/webhook-dispatch.ts
@@ -1,0 +1,117 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { enqueuePublicApiWebhookDeliver } from "@/lib/cloud-tasks";
+import { decryptSecret } from "@/lib/public-api/crypto";
+import { COLLECTIONS } from "@/lib/public-api/types";
+import { resolveAndValidateWebhookUrl } from "@/lib/public-api/ssrf";
+import { signWebhookPayload } from "@/lib/public-api/webhook-signature";
+import { nextWebhookDelaySeconds, shouldRetryWebhookStatus } from "@/lib/public-api/webhook-retry";
+import type { WebhookEndpointRecord } from "@/lib/public-api/webhooks";
+
+const DELIVER_TIMEOUT_MS = 10_000;
+
+export async function deliverWebhookJob(deliveryId: string): Promise<void> {
+  const db = getAdminDb();
+  const ref = db.collection(COLLECTIONS.webhookDeliveries).doc(deliveryId);
+  const snap = await ref.get();
+  if (!snap.exists) return;
+  const delivery = snap.data()!;
+  if (delivery.status === "delivered") return;
+
+  const epSnap = await db.collection(COLLECTIONS.webhookEndpoints).doc(String(delivery.endpointId)).get();
+  if (!epSnap.exists) {
+    await ref.update({ status: "abandoned", lastError: "endpoint_missing" });
+    return;
+  }
+  const endpoint = { id: epSnap.id, ...(epSnap.data() as Omit<WebhookEndpointRecord, "id">) };
+  if (endpoint.status !== "active") {
+    await ref.update({ status: "abandoned", lastError: "endpoint_disabled" });
+    return;
+  }
+
+  const requireHttps = endpoint.environment === "live" || process.env.NODE_ENV === "production";
+  const ssrf = await resolveAndValidateWebhookUrl(String(delivery.url || endpoint.url), { requireHttps });
+  if (!ssrf.ok) {
+    await ref.update({
+      status: "failed",
+      lastError: ssrf.code,
+      lastAttemptAt: FieldValue.serverTimestamp(),
+    });
+    return;
+  }
+
+  let secret: string;
+  try {
+    secret = decryptSecret(endpoint.secretEncrypted);
+  } catch {
+    await ref.update({ status: "abandoned", lastError: "secret_unavailable" });
+    return;
+  }
+
+  const eventId = String(delivery.eventId);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const rawBody = JSON.stringify(delivery.payload);
+  const signature = signWebhookPayload(secret, eventId, timestamp, rawBody);
+
+  const attempt = typeof delivery.attempt === "number" ? delivery.attempt : 0;
+  let status: number | null = null;
+  let networkError = false;
+  let lastError: string | null = null;
+
+  try {
+    const res = await fetch(String(delivery.url || endpoint.url), {
+      method: "POST",
+      redirect: "error",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "Notificas-Webhooks/1.0",
+        "notificas-id": eventId,
+        "notificas-timestamp": timestamp,
+        "notificas-signature": signature,
+      },
+      body: rawBody,
+      signal: AbortSignal.timeout(DELIVER_TIMEOUT_MS),
+    });
+    status = res.status;
+    if (status >= 400) lastError = `http_${status}`;
+  } catch (e) {
+    networkError = true;
+    lastError = e instanceof Error ? e.name : "network_error";
+  }
+
+  const ok = status != null && status >= 200 && status < 300;
+  const endpointPatch: Record<string, unknown> = {
+    lastAttemptAt: FieldValue.serverTimestamp(),
+    lastStatus: status,
+    lastError,
+  };
+
+  if (ok) {
+    await ref.update({
+      status: "delivered",
+      attempt: attempt + 1,
+      lastStatus: status,
+      lastError: null,
+      deliveredAt: FieldValue.serverTimestamp(),
+    });
+    await epSnap.ref.update(endpointPatch);
+    return;
+  }
+
+  const nextAttempt = attempt + 1;
+  const delay = nextWebhookDelaySeconds(nextAttempt);
+  const retry = delay != null && shouldRetryWebhookStatus(status, networkError);
+
+  await ref.update({
+    status: retry ? "pending" : "failed",
+    attempt: nextAttempt,
+    lastStatus: status,
+    lastError,
+    lastAttemptAt: FieldValue.serverTimestamp(),
+  });
+  await epSnap.ref.update(endpointPatch);
+
+  if (retry && delay != null) {
+    await enqueuePublicApiWebhookDeliver({ deliveryId }, delay);
+  }
+}

--- a/src/lib/public-api/webhook-retry.ts
+++ b/src/lib/public-api/webhook-retry.ts
@@ -1,0 +1,15 @@
+/** Backoff de reintentos de webhooks salientes (segundos). */
+export const WEBHOOK_RETRY_DELAYS_SECONDS = [0, 60, 300, 1800, 7200, 21600, 86400] as const;
+
+export function nextWebhookDelaySeconds(attemptIndex: number): number | null {
+  if (attemptIndex < 0 || attemptIndex >= WEBHOOK_RETRY_DELAYS_SECONDS.length) return null;
+  return WEBHOOK_RETRY_DELAYS_SECONDS[attemptIndex];
+}
+
+export function shouldRetryWebhookStatus(status: number | null, networkError: boolean): boolean {
+  if (networkError) return true;
+  if (status == null) return true;
+  if (status >= 500) return true;
+  if (status === 408 || status === 429) return true;
+  return false;
+}

--- a/src/lib/public-api/webhook-signature.ts
+++ b/src/lib/public-api/webhook-signature.ts
@@ -1,0 +1,49 @@
+import { hmacSha256Hex, timingSafeEqualHex } from "@/lib/public-api/crypto";
+
+export const WEBHOOK_SIGNATURE_HEADER = "notificas-signature";
+export const WEBHOOK_ID_HEADER = "notificas-id";
+export const WEBHOOK_TIMESTAMP_HEADER = "notificas-timestamp";
+
+/** Ventana anti-replay (segundos). */
+export const WEBHOOK_REPLAY_WINDOW_SECONDS = 5 * 60;
+
+export function webhookSignedPayload(eventId: string, timestamp: string, rawBody: string): string {
+  return `${eventId}.${timestamp}.${rawBody}`;
+}
+
+export function signWebhookPayload(secret: string, eventId: string, timestamp: string, rawBody: string): string {
+  const hex = hmacSha256Hex(secret, webhookSignedPayload(eventId, timestamp, rawBody));
+  return `v1=${hex}`;
+}
+
+export function parseSignatureHeader(header: string | null | undefined): string | null {
+  const raw = String(header || "").trim();
+  if (!raw) return null;
+  const part = raw.split(",").map((p) => p.trim()).find((p) => p.startsWith("v1="));
+  if (!part) return raw.startsWith("v1=") ? raw.slice(3) : raw;
+  return part.slice(3);
+}
+
+export function verifyWebhookSignature(opts: {
+  secret: string;
+  eventId: string;
+  timestamp: string;
+  rawBody: string;
+  signatureHeader: string | null | undefined;
+  nowMs?: number;
+  replayWindowSeconds?: number;
+}): { ok: true } | { ok: false; code: "invalid_signature" | "timestamp_expired" | "invalid_timestamp" } {
+  const ts = Number(opts.timestamp);
+  if (!Number.isFinite(ts) || ts <= 0) return { ok: false, code: "invalid_timestamp" };
+  const now = opts.nowMs ?? Date.now();
+  const windowMs = (opts.replayWindowSeconds ?? WEBHOOK_REPLAY_WINDOW_SECONDS) * 1000;
+  if (Math.abs(now - ts * 1000) > windowMs) return { ok: false, code: "timestamp_expired" };
+
+  const provided = parseSignatureHeader(opts.signatureHeader);
+  if (!provided) return { ok: false, code: "invalid_signature" };
+  const expectedHex = hmacSha256Hex(opts.secret, webhookSignedPayload(opts.eventId, opts.timestamp, opts.rawBody));
+  if (!timingSafeEqualHex(provided.toLowerCase(), expectedHex.toLowerCase())) {
+    return { ok: false, code: "invalid_signature" };
+  }
+  return { ok: true };
+}

--- a/src/lib/public-api/webhooks.ts
+++ b/src/lib/public-api/webhooks.ts
@@ -1,0 +1,185 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { encryptSecret, randomSecret } from "@/lib/public-api/crypto";
+import { invalidRequest, notFound } from "@/lib/public-api/errors";
+import { newEventId, newWebhookEndpointId } from "@/lib/public-api/ids";
+import { resolveAndValidateWebhookUrl } from "@/lib/public-api/ssrf";
+import type { PublicApiAuthContext } from "@/lib/public-api/types";
+import { COLLECTIONS } from "@/lib/public-api/types";
+import type { WebhookEventType } from "@/lib/public-api/validation";
+import { enqueuePublicApiWebhookDeliver } from "@/lib/cloud-tasks";
+import { nextWebhookDelaySeconds } from "@/lib/public-api/webhook-retry";
+import { assertTenant } from "@/lib/public-api/tenant";
+
+export { assertTenant } from "@/lib/public-api/tenant";
+
+export type WebhookEndpointRecord = {
+  id: string;
+  orgId: string;
+  url: string;
+  events: WebhookEventType[];
+  secretEncrypted: string;
+  secretPrefix: string;
+  status: "active" | "disabled";
+  environment: "live" | "test";
+  description?: string;
+  createdAt: unknown;
+  lastAttemptAt?: unknown;
+  lastStatus?: number | null;
+  lastError?: string | null;
+};
+
+export function publicWebhookEndpointView(row: WebhookEndpointRecord) {
+  return {
+    id: row.id,
+    url: row.url,
+    events: row.events,
+    status: row.status,
+    environment: row.environment,
+    secret_prefix: row.secretPrefix,
+    description: row.description || null,
+    created_at: toIso(row.createdAt),
+    last_attempt_at: toIso(row.lastAttemptAt),
+    last_status: row.lastStatus ?? null,
+    last_error: row.lastError ?? null,
+  };
+}
+
+function toIso(value: unknown): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && value && "toDate" in value && typeof (value as { toDate: () => Date }).toDate === "function") {
+    try {
+      return (value as { toDate: () => Date }).toDate().toISOString();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export async function createWebhookEndpoint(
+  ctx: PublicApiAuthContext,
+  input: { url: string; events: WebhookEventType[]; description?: string }
+): Promise<{ endpoint: ReturnType<typeof publicWebhookEndpointView>; secret: string }> {
+  const requireHttps = ctx.environment === "live" || process.env.NODE_ENV === "production";
+  const ssrf = await resolveAndValidateWebhookUrl(input.url, { requireHttps });
+  if (!ssrf.ok) throw invalidRequest(ssrf.code, ssrf.message, "url");
+
+  const secret = `whsec_${randomSecret(24)}`;
+  const id = newWebhookEndpointId();
+  const record: WebhookEndpointRecord = {
+    id,
+    orgId: ctx.orgId,
+    url: input.url.trim(),
+    events: input.events,
+    secretEncrypted: encryptSecret(secret),
+    secretPrefix: secret.slice(0, 12),
+    status: "active",
+    environment: ctx.environment,
+    description: input.description,
+    createdAt: FieldValue.serverTimestamp(),
+  };
+  await getAdminDb().collection(COLLECTIONS.webhookEndpoints).doc(id).set(record);
+  return { endpoint: publicWebhookEndpointView(record), secret };
+}
+
+export async function listWebhookEndpoints(ctx: PublicApiAuthContext) {
+  const snap = await getAdminDb()
+    .collection(COLLECTIONS.webhookEndpoints)
+    .where("orgId", "==", ctx.orgId)
+    .where("environment", "==", ctx.environment)
+    .get();
+  return snap.docs.map((d) => publicWebhookEndpointView({ id: d.id, ...(d.data() as Omit<WebhookEndpointRecord, "id">) }));
+}
+
+export async function getWebhookEndpoint(ctx: PublicApiAuthContext, id: string) {
+  const snap = await getAdminDb().collection(COLLECTIONS.webhookEndpoints).doc(id).get();
+  if (!snap.exists) throw notFound("webhook_endpoint_not_found", "Webhook endpoint not found.");
+  const data = { id: snap.id, ...(snap.data() as Omit<WebhookEndpointRecord, "id">) };
+  assertTenant(data.orgId, ctx.orgId);
+  if (data.environment !== ctx.environment) throw notFound("webhook_endpoint_not_found", "Webhook endpoint not found.");
+  return data;
+}
+
+export async function updateWebhookEndpoint(
+  ctx: PublicApiAuthContext,
+  id: string,
+  patch: { url?: string; events?: WebhookEventType[]; enabled?: boolean; description?: string }
+) {
+  const current = await getWebhookEndpoint(ctx, id);
+  const updates: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
+  if (patch.url) {
+    const requireHttps = ctx.environment === "live" || process.env.NODE_ENV === "production";
+    const ssrf = await resolveAndValidateWebhookUrl(patch.url, { requireHttps });
+    if (!ssrf.ok) throw invalidRequest(ssrf.code, ssrf.message, "url");
+    updates.url = patch.url.trim();
+  }
+  if (patch.events) updates.events = patch.events;
+  if (typeof patch.enabled === "boolean") updates.status = patch.enabled ? "active" : "disabled";
+  if (patch.description !== undefined) updates.description = patch.description;
+  await getAdminDb().collection(COLLECTIONS.webhookEndpoints).doc(id).update(updates);
+  return getWebhookEndpoint(ctx, id);
+}
+
+export type PublicApiEventPayload = {
+  type: WebhookEventType;
+  orgId: string;
+  environment: "live" | "test";
+  data: Record<string, unknown>;
+};
+
+/**
+ * Crea un evento único y encola una entrega por endpoint suscripto.
+ * Los reintentos reenvían el mismo event_id.
+ */
+export async function emitPublicApiEvent(payload: PublicApiEventPayload): Promise<void> {
+  const db = getAdminDb();
+  const eventId = newEventId();
+  const createdAt = new Date().toISOString();
+  const body = {
+    id: eventId,
+    type: payload.type,
+    created_at: createdAt,
+    data: payload.data,
+  };
+
+  await db.collection(COLLECTIONS.webhookEvents).doc(eventId).set({
+    orgId: payload.orgId,
+    environment: payload.environment,
+    type: payload.type,
+    createdAt: FieldValue.serverTimestamp(),
+    data: payload.data,
+  });
+
+  const snap = await db
+    .collection(COLLECTIONS.webhookEndpoints)
+    .where("orgId", "==", payload.orgId)
+    .where("status", "==", "active")
+    .where("environment", "==", payload.environment)
+    .get();
+
+  for (const doc of snap.docs) {
+    const ep = doc.data() as WebhookEndpointRecord;
+    const events = Array.isArray(ep.events) ? ep.events : [];
+    if (!events.includes(payload.type)) continue;
+    const deliveryId = `${eventId}_${doc.id}`;
+    await db.collection(COLLECTIONS.webhookDeliveries).doc(deliveryId).set({
+      id: deliveryId,
+      eventId,
+      endpointId: doc.id,
+      orgId: payload.orgId,
+      url: ep.url,
+      type: payload.type,
+      payload: body,
+      attempt: 0,
+      status: "pending",
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    const delay = nextWebhookDelaySeconds(0) ?? 0;
+    await enqueuePublicApiWebhookDeliver({ deliveryId }, delay).catch((e) =>
+      console.warn("public-api webhook enqueue failed", e instanceof Error ? e.message : e)
+    );
+  }
+}

--- a/src/lib/resend-webhook.ts
+++ b/src/lib/resend-webhook.ts
@@ -3,6 +3,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase-admin";
 import { recordProviderEvent } from "@/lib/provider-events";
 import { verifyResendSvixSignature } from "@/lib/resend-webhook-verify";
+import { syncPublicApiNotificationFromMail } from "@/lib/public-api/status-sync";
 
 export const RESEND_EMAIL_EVENTS = [
   "email.sent",
@@ -395,6 +396,15 @@ export async function processResendWebhook(input: {
       contentType: input.contentType,
       signatureValidatedAt: receivedAtIso,
     });
+    const hint =
+      eventType === "email.delivered"
+        ? "delivered"
+        : eventType === "email.sent"
+          ? "sent"
+          : eventType === "email.bounced" || eventType === "email.failed" || eventType === "email.suppressed"
+            ? "failed"
+            : undefined;
+    void syncPublicApiNotificationFromMail(mailId, hint).catch(() => undefined);
   }
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

API REST versionada en `/api/v1/` para que CRMs, ERPs, cobranzas, estudios jurídicos y agentes integren Notificas **sin duplicar** la lógica de envío, evidencia ni campañas.

Reutiliza `createMailDocumentAdmin`, `invokeSendEmail` (Cloud Function existente), fanout/worker de campañas, sellado de evidencia y constancia de envío.

## Arquitectura encontrada

Next.js 15 App Router + Firebase Auth/Firestore + Cloud Functions `sendEmail` + Cloud Tasks para campañas. El documento canónico es `mail`. Las campañas usan `campaigns` + `campaign_messages`. No existía un sistema de API Keys públicas.

## Endpoints

| Método | Endpoint | Función |
|--------|----------|---------|
| GET | `/api/v1/me` | Cuenta de la API Key |
| POST | `/api/v1/notifications` | Crear notificación |
| GET | `/api/v1/notifications` | Listar (cursor) |
| GET | `/api/v1/notifications/{id}` | Consultar |
| GET | `/api/v1/notifications/{id}/certificate` | Constancia (URL firmada 15 min) |
| POST | `/api/v1/batches` | Lote asíncrono (campaña) |
| GET | `/api/v1/batches/{id}` | Estado del lote |
| POST/GET | `/api/v1/webhook-endpoints` | Registrar / listar webhooks |
| GET/PATCH/DELETE | `/api/v1/webhook-endpoints/{id}` | Gestionar / desactivar |

Docs: `/docs/api` (Scalar) · spec: `/openapi/v1.yaml` · interno: `docs/public-api.md`

## SDK web (insertar en sitios)

Script: `https://notificas.com.ar/sdk/v1/notificas.js`

- Widget copy-paste + `Notificas.create()` / `Notificas.embed()`
- Página: `/docs/api/embed` (también `/integrar`)
- **No** se pone `ntf_live_` en el navegador: el widget usa `proxyUrl` hacia el backend del cliente
- Ejemplos de proxy: `docs/examples/nextjs-proxy-route.ts`, `docs/examples/express-proxy.js`

## Autenticación

`Authorization: Bearer ntf_live_…` o `ntf_test_…`. El secret **nunca** se guarda en texto plano (hash + pepper). Generar/revocar: panel `/admin/api-keys` o `npx tsx scripts/create-api-key.ts --orgId …`.

## Seguridad

Aislamiento por `orgId` de la clave (ID ajeno = 404). Zod estricto (anti mass assignment). SSRF en webhooks. HMAC-SHA256 + anti-replay. Rate limit por API Key. Sandbox sin envíos reales salvo allowlist. Auditoría sin secretos. `X-Request-Id`.

## Tests

`npm test` incluye 5 tests del SDK (bloqueo de `ntf_live_` en browser, proxy sin Authorization, errores de API). `tsc --noEmit` OK.

## Deploy

1. Merge y deploy App Hosting.
2. `firebase deploy --only firestore:indexes,firestore:rules`
3. Generar una API Key en `/admin/api-keys`.
4. Probar `GET /api/v1/me`, `/docs/api` y `/docs/api/embed`.

## Pendientes (requieren acción tuya)

- Generar la primera API Key de la empresa destino.
- Opcional: `PUBLIC_API_KEY_PEPPER` y `PUBLIC_API_ENCRYPTION_KEY` dedicados en Secret Manager.
- Allowlist de sandbox si querés envíos reales de prueba.
- Registrar el webhook HTTPS del cliente.
- Esperar a que Firestore construya los índices nuevos antes de usar listados filtrados en producción.
- El widget de producción necesita un proxy en el backend del cliente (la key no va al HTML).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25300f91-43db-46fd-b3b7-6b5f203b9d1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25300f91-43db-46fd-b3b7-6b5f203b9d1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

