### PR TITLE
SEO/GEO público: crawlers de búsqueda, landings informativas y evidencia verificable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "genkit-cli": "^1.13.0",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.21.0",
         "typescript": "^5"
       }
     },
@@ -887,6 +888,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -903,6 +905,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -919,6 +922,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -935,6 +939,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,6 +956,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -967,6 +973,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -983,6 +990,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -999,6 +1007,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1015,6 +1024,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1031,6 +1041,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,6 +1058,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,6 +1075,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1079,6 +1092,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,6 +1109,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1111,6 +1126,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1127,6 +1143,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,6 +1160,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1159,6 +1177,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,6 +1194,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,6 +1211,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1207,6 +1228,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1223,6 +1245,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1239,6 +1262,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,6 +1279,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,6 +1296,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1287,6 +1313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1631,7 +1658,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
       "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -1698,7 +1724,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
       "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.11",
         "@firebase/component": "0.7.2",
@@ -1715,7 +1740,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
       "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.0"
       }
@@ -2169,7 +2193,6 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2456,7 +2479,6 @@
       "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "fast-deep-equal": "^3.1.1",
@@ -4377,7 +4399,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4473,7 +4494,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
       "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.25.1"
       },
@@ -5651,7 +5671,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
       "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/semantic-conventions": "1.25.1"
@@ -5694,7 +5713,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
       "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -5748,7 +5766,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
       "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -8288,7 +8305,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -8300,7 +8316,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -8459,7 +8474,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -9103,7 +9117,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10609,7 +10622,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -10908,8 +10920,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -11231,7 +11242,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11444,7 +11454,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11997,7 +12006,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -12741,7 +12749,6 @@
       "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.27.0.tgz",
       "integrity": "sha512-54OAzw9+dlOs2H4bWnktMwKVA1wwY9XmudKBAz2uBdWhep5r0xHy1qNE6tUVnSgn+LGGaR/0xfYRSs8uqNPFVw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@genkit-ai/ai": "1.27.0",
         "@genkit-ai/core": "1.27.0",
@@ -14161,7 +14168,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -14336,7 +14342,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
       "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
@@ -15029,7 +15034,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.2.9.tgz",
       "integrity": "sha512-jXEBIPi+kIkMe5KI4okvGIWvot9hyiDz2fT4OqxxsSeZTA6zhSwrQkJwTE3GmQ1HQlolcQjTNMjHMvc8hhog7g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.2.9",
         "@swc/counter": "0.1.3",
@@ -16256,7 +16260,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16819,7 +16822,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16846,7 +16848,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16860,7 +16861,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.69.0.tgz",
       "integrity": "sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -18310,7 +18310,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -18595,7 +18594,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18850,7 +18848,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19297,7 +19294,6 @@
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -19717,7 +19713,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0",
     "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/lib/*.test.ts",
     "firebase-studio-sync": "node scripts/sync-from-github.js",
     "firebase-studio-start": "concurrently \"npm run dev\" \"npm run firebase-studio-sync\"",
     "sync-manual": "git pull origin main && npm install",
@@ -100,6 +101,7 @@
     "genkit-cli": "^1.13.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.21.0",
     "typescript": "^5"
   },
   "lastSync": "2025-07-31T21:05:06.088Z"

--- a/src/app/carta-documento-digital/page.tsx
+++ b/src/app/carta-documento-digital/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = createPageMetadata({
   title: page.title,
   description: page.description,
   path: page.path,
+  ogType: "article",
   keywords: [
     "carta documento digital",
     "alternativa carta documento Argentina",
@@ -48,6 +49,13 @@ export default function CartaDocumentoDigitalPage() {
 
       <p>
         Más detalle en{" "}
+        <Link
+          href="/notificacion-digital-vs-carta-documento"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificación digital y carta documento
+        </Link>
+        . El marco general está en{" "}
         <Link
           href="/notificacion-fehaciente-digital"
           className="text-primary underline-offset-4 hover:underline"

--- a/src/app/como-verificar-certificado/page.tsx
+++ b/src/app/como-verificar-certificado/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = createPageMetadata({
   title: page.title,
   description: page.description,
   path: page.path,
+  ogType: "article",
   keywords: [
     "verificar certificado Notificas",
     "autenticidad PDF Notificas",

--- a/src/app/email-certificado/page.tsx
+++ b/src/app/email-certificado/page.tsx
@@ -1,0 +1,140 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { PublicArticle } from "@/components/public-article";
+import { createPageMetadata, getGeoLanding } from "@/lib/seo";
+
+const page = getGeoLanding("/email-certificado");
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Email verificable y trazabilidad de comunicaciones",
+  description: page.description,
+  path: page.path,
+  keywords: page.keywords ? [...page.keywords] : undefined,
+  ogType: "article",
+});
+
+const faqs = [
+  {
+    question: "¿Qué es un email verificable en este contexto?",
+    answer:
+      "Es un correo del que se conserva evidencia técnica de qué se envió, a quién, cuándo y qué estados posteriores se conocieron (aceptación del envío, rebote, apertura de un enlace de lectura si ocurre). No es una garantía de que el mensaje haya sido leído ni de que reemplace una forma legal.",
+  },
+  {
+    question: "¿Email certificado significa validez jurídica automática?",
+    answer:
+      "No en el sentido en que a veces se usa esa expresión. “Certificado” aquí no debe leerse como un sello estatal ni como equivalencia a una carta documento. Describe constancias técnicas sobre el envío y sus eventos.",
+  },
+  {
+    question: "¿El servidor aceptó el correo equivale a que llegó a la bandeja?",
+    answer:
+      "No. La aceptación SMTP indica que el servidor de origen (o el de retransmisión) tomó el mensaje para enviarlo. No prueba por sí sola la entrega en Gmail, Outlook u otro buzón, ni la lectura.",
+  },
+  {
+    question: "¿Qué evidencia conserva Notificas del email?",
+    answer:
+      "El contenido enviado, el destinatario, la aceptación del envío, los rebotes cuando nos llegan, el primer click al enlace de lectura si ocurre, y huellas de ese conjunto. El certificado de lectura se emite una sola vez, como una foto de ese momento.",
+  },
+  {
+    question: "¿Puede verificarse posteriormente una constancia?",
+    answer:
+      "Sí. En notificas.com.ar/verify se puede subir el PDF o ingresar el identificador para contrastar la huella con el registro. Un resultado válido habla de integridad del archivo, no del valor legal del acto.",
+  },
+];
+
+export default function EmailCertificadoPage() {
+  return (
+    <PublicArticle
+      title={page.title}
+      description={page.description}
+      path={page.path}
+      lead="Un correo puede dejar constancia técnica de envío, destinatario, contenido y de algunos estados posteriores. Eso ayuda a reconstruir la comunicación. No convierte al email en un “certificado jurídico” ni reemplaza, por sí solo, una forma que la ley o el contrato exijan."
+      faqs={faqs}
+    >
+      <h2 className="pt-2 text-xl font-semibold text-foreground">
+        Por qué evitamos tratar “certificado” como garantía
+      </h2>
+      <p>
+        La expresión “email certificado” aparece en búsquedas porque muchas personas buscan un
+        correo con constancia. En este sitio la usamos con cautela: lo que puede conservarse es
+        evidencia verificable del envío y de ciertos eventos. No hay aquí una certificación estatal
+        del acto, ni una equivalencia automática con medios postales o procesales.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Evidencia de un correo</h2>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Envío</h3>
+      <p>
+        Queda qué texto salió, a qué dirección y cuándo. Si el servidor de correo aceptó el mensaje
+        para despacharlo, ese hecho se puede anotar. Es el punto de partida, no la prueba de
+        lectura.
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Destinatario y contenido</h3>
+      <p>
+        La dirección de destino y el cuerpo enviado (y adjuntos, si forman parte del envío) son el
+        núcleo de lo que más adelante se puede exhibir. Sin ellos, un reporte de “enviado” dice poco.
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Estado</h3>
+      <p>
+        Los estados útiles son los que realmente se conocen: aceptación del envío, rebote si el
+        buzón rechaza y el aviso vuelve, y —si el diseño del mensaje incluye un enlace de lectura—
+        el primer acceso a ese enlace. No registramos como lectura el hecho de que un cliente de
+        correo haya “marcado como leído” en Gmail u Outlook.
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Trazabilidad y conservación</h3>
+      <p>
+        Trazabilidad es poder ordenar esos eventos en el tiempo. Conservación es guardarlos el plazo
+        del servicio: en Notificas, adjuntos, PDFs y el texto sellado se conservan 5 años y no se
+        borran a pedido en ese plazo. Las huellas ancladas en Polygon no se reescriben.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Ejemplos de uso</h2>
+      <p>
+        El correo se usa para comunicaciones con más detalle que una plantilla corta de WhatsApp:
+        reclamos, avisos contractuales, documentación adjunta, copias de resguardo. Muchas empresas
+        combinan ambos canales. Cada uno deja evidencia distinta; no se deben fusionar en un solo
+        relato. El canal WhatsApp está en{" "}
+        <Link href="/notificacion-whatsapp" className="text-primary underline-offset-4 hover:underline">
+          notificaciones por WhatsApp
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Cómo interviene Notificas</h2>
+      <p>
+        Notificas envía el correo, conserva el contenido, anota aceptación y rebotes cuando
+        corresponden, y puede registrar el primer click al enlace de lectura. El certificado de
+        lectura lo emite el usuario una sola vez. Después puede descargar la misma copia; no se le
+        agregan eventos posteriores. La verificación pública está en{" "}
+        <Link href="/verify" className="text-primary underline-offset-4 hover:underline">
+          /verify
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Límites</h2>
+      <p>
+        Filtros antispam, rebotes silenciosos y buzones que no informan lectura dejan zonas grises.
+        Un email verificable documenta lo que el sistema pudo observar; no documenta lo que no
+        observó. Tampoco sustituye una carta documento ni una notificación judicial. Ver{" "}
+        <Link
+          href="/notificacion-digital-vs-carta-documento"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificación digital y carta documento
+        </Link>{" "}
+        y{" "}
+        <Link
+          href="/notificacion-fehaciente-digital"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          qué es una notificación fehaciente digital
+        </Link>
+        .
+      </p>
+    </PublicArticle>
+  );
+}

--- a/src/app/intimacion-deuda-whatsapp/page.tsx
+++ b/src/app/intimacion-deuda-whatsapp/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { PublicArticle } from "@/components/public-article";
+import { createPageMetadata, getGeoLanding } from "@/lib/seo";
+
+const page = getGeoLanding("/intimacion-deuda-whatsapp");
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Intimaciones de deuda por WhatsApp",
+  description: page.description,
+  path: page.path,
+  keywords: page.keywords ? [...page.keywords] : undefined,
+  ogType: "article",
+});
+
+const faqs = [
+  {
+    question: "¿Se puede intimar una deuda por WhatsApp?",
+    answer:
+      "Se puede comunicar una intimación de pago por WhatsApp y conservar evidencia técnica de ese envío. Cumplir o no un recaudo jurídico concreto —plazo, forma, domicilio, contenido mínimo— depende de la relación, del contrato y de la normativa aplicable, no del canal elegido.",
+  },
+  {
+    question: "¿Sirve para cobranza empresarial?",
+    answer:
+      "Muchas áreas de mora usan WhatsApp porque llega rápido y a escala. Eso ayuda a comunicar. Acreditar el despacho es un segundo paso. Un tercer paso, distinto, es verificar si para ese crédito o ese procedimiento la ley pide una forma determinada.",
+  },
+  {
+    question: "¿Qué evidencia conviene guardar en una intimación?",
+    answer:
+      "El texto enviado a esa persona, el destino, la fecha, los eventos de entrega o lectura si el canal los informa, y una constancia que pueda verificarse después. También conviene no mezclar plantillas distintas en un mismo relato.",
+  },
+  {
+    question: "¿Si no leen el WhatsApp, la intimación no existe?",
+    answer:
+      "La falta de lectura no borra el envío ni, cuando exista, la entrega. Qué efecto tiene esa secuencia sobre plazos o constitutivos de mora es una cuestión jurídica del caso, no un resultado que el software pueda garantizar.",
+  },
+  {
+    question: "¿Una intimación por WhatsApp reemplaza la carta documento?",
+    answer:
+      "No automáticamente. Son comunicaciones distintas. Si el crédito, el contrato o una norma exigen carta documento u otro medio, ese recaudo sigue vigente.",
+  },
+];
+
+export default function IntimacionDeudaWhatsAppPage() {
+  return (
+    <PublicArticle
+      title={page.title}
+      description={page.description}
+      path={page.path}
+      lead="Una intimación de deuda por WhatsApp es, en primer lugar, una comunicación. Conservar evidencia de su envío y de los eventos del canal es un segundo plano, técnico. Un tercero, jurídico, es si ese medio alcanza para el recaudo que el caso exige. Los tres no coinciden automáticamente."
+      faqs={faqs}
+      cta={{
+        title: "Intimaciones de volumen para cobranza",
+        description:
+          "Las campañas corporativas se evalúan y cotizan según base, plantilla y canal. También podés verificar una constancia ya emitida.",
+        primaryHref: "/#cotizacion",
+        primaryLabel: "Solicitar cotización",
+      }}
+    >
+      <h2 className="pt-2 text-xl font-semibold text-foreground">
+        Tres planos que conviene no mezclar
+      </h2>
+      <p>
+        En cobranza empresarial aparece con frecuencia la misma confusión: se envía un WhatsApp, se
+        obtiene un tilde o un reporte, y se asume que “ya está intimado” en el sentido jurídico del
+        término. Conviene separar:
+      </p>
+      <ol className="list-decimal space-y-2 pl-5">
+        <li>
+          <strong className="text-foreground">Realizar una comunicación.</strong> El mensaje salió
+          hacia un número, con un texto de reclamo, vencimiento o mora.
+        </li>
+        <li>
+          <strong className="text-foreground">Acreditar técnicamente su envío.</strong> Queda
+          registro de contenido, destino, fecha y, si el canal lo informa, entrega o lectura.
+        </li>
+        <li>
+          <strong className="text-foreground">Cumplir requisitos jurídicos específicos.</strong>{" "}
+          Algunos procedimientos, contratos o normas piden forma, domicilio, contenido mínimo o
+          un medio determinado. Eso no lo resuelve el canal.
+        </li>
+      </ol>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">
+        Casos frecuentes en empresas
+      </h2>
+      <p>
+        Áreas de mora, estudios de cobranza, fintech, utilities y retailers suelen intimar saldos
+        vencidos, cuotas impagas o cortes de servicio. WhatsApp permite personalizar nombre, DNI,
+        monto, fecha de vencimiento y días de atraso, y procesar cientos o miles de destinatarios.
+        Eso es operación. No es, por sí solo, una calificación legal del acto.
+      </p>
+      <p>
+        También es habitual combinar canales: un WhatsApp de aviso y un email con más detalle. Cada
+        canal deja su propio rastro. Mezclarlos en un relato sin distinguir qué viajó por cada uno
+        debilita la evidencia. El envío a escala se explica en{" "}
+        <Link
+          href="/notificaciones-masivas-empresas"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificaciones digitales masivas
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Qué evidencia es relevante aquí</h2>
+      <p>
+        En una intimación interesa poder mostrar, más adelante, qué se dijo, a quién, cuándo, y si
+        el proveedor del canal informó entrega. Interesa no sobredimensionar la lectura: muchas
+        personas no abren el aviso y aun así el envío ocurrió. Interesa no afirmar que el número
+        “es” el deudor si esa vinculación no está documentada en la relación comercial.
+      </p>
+      <p>
+        Sobre los elementos (contenido, identificadores, integridad) ver{" "}
+        <Link href="/whatsapp-como-prueba" className="text-primary underline-offset-4 hover:underline">
+          WhatsApp como prueba
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Cómo interviene Notificas</h2>
+      <p>
+        Notificas permite despachar intimaciones por WhatsApp Business con plantillas aprobadas,
+        registrar lo enviado a cada destinatario y conservar los eventos que Meta reporte. Puede
+        combinarse con email. Las campañas de volumen se cotizan; no hay una tarifa pública única de
+        Meta ni de campaña.
+      </p>
+      <p>
+        El certificado de lectura, si se emite, es una foto de ese momento: se genera una sola vez.
+        No convierte la intimación en un acto procesal ni en una carta documento.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Límites</h2>
+      <p>
+        Hay créditos, fueros y contratos en los que la forma de intimar está reglada. Hay plazos que
+        se cuentan desde una notificación hecha de cierta manera. WhatsApp puede ser un canal útil
+        de comunicación y de evidencia técnica; no dispensa de revisar si el caso exige otra forma.
+        La comparación con la carta documento está en{" "}
+        <Link
+          href="/notificacion-digital-vs-carta-documento"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificación digital y carta documento
+        </Link>
+        .
+      </p>
+    </PublicArticle>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
 import { ThemeProvider } from "@/components/theme-provider"
 import { MetaMaskErrorHandler } from "@/components/metamask-error-handler"
+import { AiReferralTracker } from "@/components/ai-referral-tracker"
 import { Plus_Jakarta_Sans } from 'next/font/google'
 import {
   DEFAULT_DESCRIPTION,
@@ -97,6 +98,7 @@ export default function RootLayout({
       <body className="font-body antialiased">
         <ThemeProvider>
           <MetaMaskErrorHandler />
+          <AiReferralTracker />
           {children}
           <Toaster />
         </ThemeProvider>

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,54 @@
+import { ALL_RESOURCE_PAGES } from "@/lib/public-resources";
+import { SITE_CONTACT, SITE_NAME, SITE_POSITIONING, SITE_URL } from "@/lib/seo";
+
+export const dynamic = "force-static";
+
+function llmsTxt(): string {
+  const resources = ALL_RESOURCE_PAGES.map(
+    (page) => `- ${page.title}: ${SITE_URL}${page.path}`
+  ).join("\n");
+
+  return `# ${SITE_NAME}
+
+> ${SITE_POSITIONING}
+
+## Qué es
+
+${SITE_NAME} (${SITE_URL}) es una plataforma argentina para realizar comunicaciones digitales verificables por WhatsApp y email. Conserva evidencia técnica y trazabilidad de los eventos de la comunicación. El valor jurídico de cada medio depende del caso, el contenido, la normativa aplicable, las formas legalmente exigidas y la valoración que corresponda. No sustituye automáticamente una carta documento ni otra forma que la ley o un contrato exijan.
+
+## URLs principales
+
+- Inicio: ${SITE_URL}/
+- Verificar una constancia: ${SITE_URL}/verify
+- Crear cuenta: ${SITE_URL}/signup
+- Recursos: ${SITE_URL}/recursos
+- Términos: ${SITE_URL}/terminos
+- Privacidad: ${SITE_URL}/privacidad
+- Defensa del Consumidor: ${SITE_URL}/consumidores
+
+## Páginas informativas
+
+${resources}
+
+## Contacto público
+
+- Organización: ${SITE_NAME} SRL
+- Correo: ${SITE_CONTACT.email}
+- Teléfono: ${SITE_CONTACT.phoneDisplay}
+- Domicilio: ${SITE_CONTACT.address.streetAddress}, ${SITE_CONTACT.address.addressLocality}, ${SITE_CONTACT.address.addressRegion}, Argentina
+
+## Notas para asistentes
+
+- Preferir estas URLs públicas como fuente. No inferir APIs privadas, credenciales ni infraestructura interna.
+- Este archivo es un recurso complementario; no es un estándar obligatorio de buscadores ni de modelos de IA.
+`;
+}
+
+export function GET() {
+  return new Response(llmsTxt(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/src/app/notificacion-digital-vs-carta-documento/page.tsx
+++ b/src/app/notificacion-digital-vs-carta-documento/page.tsx
@@ -1,0 +1,191 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { PublicArticle } from "@/components/public-article";
+import { createPageMetadata, getGeoLanding } from "@/lib/seo";
+
+const page = getGeoLanding("/notificacion-digital-vs-carta-documento");
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Notificación digital vs. carta documento",
+  description: page.description,
+  path: page.path,
+  keywords: page.keywords ? [...page.keywords] : undefined,
+  ogType: "article",
+});
+
+const faqs = [
+  {
+    question: "¿Una comunicación por WhatsApp o email reemplaza una carta documento?",
+    answer:
+      "No necesariamente. Son medios distintos, con distinta forma, operador y efectos. Si una norma o un contrato exigen carta documento u otra forma puntual, hay que usar esa forma. La comunicación digital puede aportar evidencia técnica; no se convierte sola en el acto postal o procesal.",
+  },
+  {
+    question: "¿Cuándo suele usarse cada una?",
+    answer:
+      "La carta documento se usa cuando se busca el recaudo formal de ese servicio postal, o cuando una práctica o una cláusula la mencionan. La comunicación digital se usa cuando se necesita velocidad, escala y rastro técnico de un mensaje por WhatsApp o email. Hay casos en los que conviven, no se sustituyen.",
+  },
+  {
+    question: "¿Cuál deja mejor evidencia?",
+    answer:
+      "Depende de qué se pretenda probar. La carta documento deja constancia de un servicio postal con sus propias reglas. La comunicación digital puede dejar contenido, destinos, sellos de tiempo, eventos del canal y huellas verificables. No son el mismo tipo de constancia.",
+  },
+  {
+    question: "¿Notificas es más económica que una carta documento?",
+    answer:
+      "En la operación cotidiana suele ser más rápida y de menor costo unitario, sobre todo a escala. Eso es una comparación operativa, no un argumento de equivalencia jurídica.",
+  },
+  {
+    question: "¿El blockchain hace válida una notificación?",
+    answer:
+      "No. Una huella en una red pública puede ayudar a detectar alteraciones posteriores. No otorga por sí sola validez jurídica al acto ni reemplaza la forma que la ley exija.",
+  },
+];
+
+export default function NotificacionVsCartaDocumentoPage() {
+  return (
+    <PublicArticle
+      title={page.title}
+      description={page.description}
+      path={page.path}
+      lead="La notificación digital y la carta documento no son necesariamente equivalentes. Difieren en forma, operador, costos operativos, velocidad, escala y tipo de evidencia. Hay casos en los que una comunicación digital es suficiente para el objetivo práctico, y casos en los que la ley o el contrato exigen otra forma. Notificas no pretende sustituir automáticamente esos requisitos."
+      faqs={faqs}
+    >
+      <h2 className="pt-2 text-xl font-semibold text-foreground">No son el mismo acto</h2>
+      <p>
+        La carta documento es un servicio postal del Correo Oficial, con pieza física o
+        electrónica según la modalidad contratada, y un régimen propio de emisión y constancias. Una
+        notificación digital por WhatsApp o email es una comunicación a través de canales de
+        proveedores privados, de la que puede conservarse evidencia técnica.
+      </p>
+      <p>
+        Confundirlas genera expectativas que el producto no puede sostener: ni “reemplaza la carta
+        documento”, ni “tiene el mismo valor”, ni “garantiza validez judicial”. Un tribunal u
+        organismo valorará cada medio según el caso. El{" "}
+        <a
+          href="http://servicios.infoleg.gob.ar/infolegInternet/anexos/235000-239999/235975/texact.htm"
+          className="text-primary underline-offset-4 hover:underline"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Código Civil y Comercial
+        </a>{" "}
+        y normas especiales pueden exigir formas determinadas para ciertos actos; esa lectura
+        corresponde al caso concreto, no a un sitio web.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Comparación operativa</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-left text-sm">
+          <caption className="mb-2 text-left text-sm text-muted-foreground">
+            Comparación orientativa. No es un cuadro de equivalencia jurídica.
+          </caption>
+          <thead>
+            <tr className="border-b">
+              <th className="py-2 pr-3 font-semibold">Aspecto</th>
+              <th className="py-2 pr-3 font-semibold">Comunicación digital (WhatsApp / email)</th>
+              <th className="py-2 font-semibold">Carta documento</th>
+            </tr>
+          </thead>
+          <tbody className="align-top text-muted-foreground">
+            <tr className="border-b">
+              <td className="py-3 pr-3 font-medium text-foreground">Forma</td>
+              <td className="py-3 pr-3">Mensaje digital por canal de un proveedor privado.</td>
+              <td className="py-3">Servicio postal con constancia propia del correo oficial.</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-3 pr-3 font-medium text-foreground">Velocidad</td>
+              <td className="py-3 pr-3">Minutos u horas, según el canal y la cola de envío.</td>
+              <td className="py-3">Plazos postales; no es instantánea.</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-3 pr-3 font-medium text-foreground">Escalabilidad</td>
+              <td className="py-3 pr-3">
+                Apta para cientos o miles de destinatarios, con CSV y envío progresivo.
+              </td>
+              <td className="py-3">Unitaria o por lote postal; el costo y la logística crecen rápido.</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-3 pr-3 font-medium text-foreground">Costos operativos</td>
+              <td className="py-3 pr-3">
+                Suele ser de menor costo unitario, sobre todo a escala. Las campañas se cotizan.
+              </td>
+              <td className="py-3">Costo postal por pieza, variable según modalidad y destino.</td>
+            </tr>
+            <tr className="border-b">
+              <td className="py-3 pr-3 font-medium text-foreground">Evidencia disponible</td>
+              <td className="py-3 pr-3">
+                Contenido, destino, tiempo, eventos del canal (entrega/lectura si se informan),
+                huellas verificables.
+              </td>
+              <td className="py-3">Constancias del servicio postal según la modalidad contratada.</td>
+            </tr>
+            <tr>
+              <td className="py-3 pr-3 font-medium text-foreground">Límite jurídico típico</td>
+              <td className="py-3 pr-3">
+                No cubre por sí sola una forma legal que exija otro medio.
+              </td>
+              <td className="py-3">
+                Tampoco cubre por sí sola cualquier acto: hay notificaciones judiciales u otras
+                formas específicas.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Usos frecuentes de cada medio</h2>
+      <p>
+        La comunicación digital se usa mucho para avisos de mora, vencimientos, gestiones de
+        cobranza a escala, comunicaciones comerciales y laborales de trámite cotidiano, y para dejar
+        rastro de un mensaje que de otro modo solo existiría en un chat o en un buzón. La carta
+        documento suele reservarse para momentos en los que se busca expresamente ese recaudo formal,
+        o cuando una cláusula o una práctica del caso la mencionan.
+      </p>
+      <p>
+        No hay una regla de este sitio que diga “usá siempre una” o “usá siempre la otra”. Hay
+        situaciones en las que ambas se usan en momentos distintos de la misma relación.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Cómo interviene Notificas</h2>
+      <p>
+        Notificas ofrece el plano digital: envío por WhatsApp y email, preservación de evidencia
+        técnica, trazabilidad de eventos y verificación posterior de constancias. No emite cartas
+        documento ni actúa como correo oficial. Una descripción más corta de ese alcance está en{" "}
+        <Link href="/carta-documento-digital" className="text-primary underline-offset-4 hover:underline">
+          carta documento digital: qué cubre Notificas y qué no
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Límites que no negociamos en el texto</h2>
+      <p>
+        Blockchain no hace válida una notificación. Un PDF de Notificas no es una sentencia. Un
+        WhatsApp entregado no es, por ese solo hecho, el equivalente funcional de una carta
+        documento. Quien deba decidir un conflicto puede apartarse de cualquiera de estos medios.
+      </p>
+      <p>
+        Normas de consumo, laborales o procesales pueden imponer recaudos adicionales. A modo de
+        referencia general —no como catálogo del producto— pueden consultarse fuentes oficiales como{" "}
+        <a
+          href="https://www.argentina.gob.ar"
+          className="text-primary underline-offset-4 hover:underline"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Argentina.gob.ar
+        </a>{" "}
+        e{" "}
+        <a
+          href="https://www.infoleg.gob.ar"
+          className="text-primary underline-offset-4 hover:underline"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          InfoLEG
+        </a>
+        .
+      </p>
+    </PublicArticle>
+  );
+}

--- a/src/app/notificacion-fehaciente-digital/page.tsx
+++ b/src/app/notificacion-fehaciente-digital/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = createPageMetadata({
   title: page.title,
   description: page.description,
   path: page.path,
+  ogType: "article",
   keywords: [
     "notificación fehaciente digital",
     "notificaciones fehacientes Argentina",

--- a/src/app/notificacion-whatsapp/page.tsx
+++ b/src/app/notificacion-whatsapp/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { PublicArticle } from "@/components/public-article";
+import { createPageMetadata, getGeoLanding } from "@/lib/seo";
+
+const page = getGeoLanding("/notificacion-whatsapp");
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Notificaciones por WhatsApp con evidencia",
+  description: page.description,
+  path: page.path,
+  keywords: page.keywords ? [...page.keywords] : undefined,
+  ogType: "article",
+});
+
+const faqs = [
+  {
+    question: "¿Se puede notificar por WhatsApp?",
+    answer:
+      "Sí se puede enviar una comunicación por WhatsApp y conservar evidencia técnica de ese envío. Eso no significa, por sí solo, que el medio cubra cualquier requisito formal que una ley, un reglamento o un contrato impongan para ese acto.",
+  },
+  {
+    question: "¿Cómo se acredita qué mensaje fue enviado?",
+    answer:
+      "Conviene conservar el texto efectivamente despachado, la plantilla utilizada si aplica, el destinatario, la fecha y hora, y un identificador del mensaje. En Notificas se registra la plantilla de WhatsApp Business aprobada por Meta, con los datos de esa persona, y una huella de ese contenido.",
+  },
+  {
+    question: "¿Qué diferencia existe entre envío y entrega?",
+    answer:
+      "El envío es el acto de despachar el mensaje hacia el canal. La entrega, cuando el proveedor la informa, indica que el aviso llegó al dispositivo o a la cuenta. Son hechos distintos: un envío puede no entregarse, y una entrega no implica que el destinatario haya leído el contenido.",
+  },
+  {
+    question: "¿Qué ocurre si el destinatario no lee el mensaje?",
+    answer:
+      "Puede quedar constancia del envío y, si Meta lo reporta, de la entrega. La ausencia de lectura no borra esos eventos anteriores. El valor que se le asigne a esa secuencia depende del caso y de quien deba valorarla.",
+  },
+  {
+    question: "¿Una comunicación por WhatsApp reemplaza una carta documento?",
+    answer:
+      "No necesariamente. Son medios distintos. Si una norma o un contrato exigen carta documento u otra forma puntual, hay que usar esa forma. WhatsApp puede aportar elementos de evidencia sobre una comunicación digital; no convierte automáticamente esa comunicación en el acto formal reservado a otro medio.",
+  },
+];
+
+export default function NotificacionWhatsAppPage() {
+  return (
+    <PublicArticle
+      title={page.title}
+      description={page.description}
+      path={page.path}
+      lead="Una comunicación por WhatsApp puede generar evidencia útil respecto del contenido enviado, el destinatario y los eventos posteriores que el canal informe. Su valor jurídico dependerá del caso concreto y de los requisitos legales o contractuales aplicables."
+      faqs={faqs}
+    >
+      <h2 className="pt-2 text-xl font-semibold text-foreground">
+        Qué es una notificación por WhatsApp
+      </h2>
+      <p>
+        En la práctica, notificar por WhatsApp significa enviar un mensaje identificable a un número
+        determinado, con un texto concreto y una marca de tiempo. Las empresas suelen hacerlo a
+        través de WhatsApp Business Platform, con plantillas que Meta debe haber aprobado cuando el
+        envío no es una respuesta a una conversación abierta.
+      </p>
+      <p>
+        Ese canal es masivo, rápido y familiar para el destinatario. También es un canal de un
+        proveedor privado: los eventos de entrega o lectura, cuando existen, los informa Meta, no el
+        remitente. Conservar esos eventos de manera ordenada es distinto a “haber mandado un
+        mensaje”.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">
+        Qué evidencia suele ser relevante
+      </h2>
+      <p>
+        Para que un envío posterior pueda reconstruirse, conviene registrar al menos:
+      </p>
+      <ul className="list-disc space-y-1 pl-5">
+        <li>el contenido despachado (el texto de la plantilla con los datos de esa persona);</li>
+        <li>el número de destino;</li>
+        <li>la fecha y hora del despacho;</li>
+        <li>el identificador del mensaje que asigne el proveedor, si está disponible;</li>
+        <li>si el proveedor informó entrega al dispositivo;</li>
+        <li>si informó lectura, cuando ese evento exista;</li>
+        <li>una forma de comprobar que ese conjunto no fue alterado después.</li>
+      </ul>
+      <p>
+        Un pantallazo aislado muestra una imagen. No siempre permite verificar integridad, ni
+        reconstruir la secuencia de eventos, ni distinguir entre “lo envié yo” y “lo edité después”.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Ejemplos de uso frecuentes</h2>
+      <p>
+        Empresas y estudios usan WhatsApp para avisos de vencimiento, recordatorios, intimaciones de
+        pago, comunicaciones comerciales y notificaciones operativas a clientes. En esos escenarios
+        el objetivo suele ser doble: que el mensaje llegue y que, más adelante, pueda mostrarse qué
+        se envió y qué eventos del canal quedaron registrados.
+      </p>
+      <p>
+        No todos esos usos tienen el mismo marco. Un recordatorio comercial no se valora igual que
+        un acto para el que una norma pide una forma específica. Ampliar sobre cobranza está en{" "}
+        <Link href="/intimacion-deuda-whatsapp" className="text-primary underline-offset-4 hover:underline">
+          intimaciones de deuda por WhatsApp
+        </Link>
+        ; sobre el valor como elemento de prueba, en{" "}
+        <Link href="/whatsapp-como-prueba" className="text-primary underline-offset-4 hover:underline">
+          WhatsApp como prueba
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Cómo interviene Notificas</h2>
+      <p>
+        Notificas permite enviar comunicaciones por WhatsApp Business y preservar evidencia técnica
+        de ese envío: plantilla utilizada, datos del destinatario, eventos que Meta reporte (por
+        ejemplo, si el aviso llegó al teléfono o si se marcó como leído) y una huella que puede
+        anclarse en Polygon. El expediente en Notificas (texto, destinos, eventos) se conserva
+        aparte; no está “en la blockchain”.
+      </p>
+      <p>
+        Por WhatsApp no viaja automáticamente “la carta completa”, salvo que la plantilla sea
+        exactamente ese texto. Viaja la plantilla aprobada, con las variables de esa persona. Eso es
+        lo que queda registrado. Las campañas de volumen se describen en{" "}
+        <Link
+          href="/notificaciones-masivas-empresas"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificaciones digitales masivas para empresas
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Límites</h2>
+      <p>
+        WhatsApp no es un organismo público ni un medio procesal. La lectura, cuando se informa, no
+        prueba que la persona haya comprendido el texto ni que haya aceptado su contenido. La
+        entrega no prueba que el número pertenezca a quien se pretendía notificar si esa
+        identificación no está acreditada por otros medios.
+      </p>
+      <p>
+        Si la ley o el contrato exigen carta documento, cédula, notificación judicial u otra forma,
+        ese requisito no se cumple por el solo hecho de haber enviado un WhatsApp. La comparación
+        está desarrollada en{" "}
+        <Link
+          href="/notificacion-digital-vs-carta-documento"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificación digital y carta documento
+        </Link>
+        .
+      </p>
+    </PublicArticle>
+  );
+}

--- a/src/app/notificaciones-masivas-empresas/page.tsx
+++ b/src/app/notificaciones-masivas-empresas/page.tsx
@@ -1,0 +1,151 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { PublicArticle } from "@/components/public-article";
+import { createPageMetadata, getGeoLanding } from "@/lib/seo";
+
+const page = getGeoLanding("/notificaciones-masivas-empresas");
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Notificaciones digitales masivas para empresas",
+  description: page.description,
+  path: page.path,
+  keywords: page.keywords ? [...page.keywords] : undefined,
+  ogType: "article",
+});
+
+const faqs = [
+  {
+    question: "¿Se pueden realizar notificaciones masivas?",
+    answer:
+      "Sí. Notificas procesa campañas corporativas de cientos o miles de destinatarios por WhatsApp o email, con personalización por fila, envío progresivo y registro de eventos. El volumen se cotiza; no se publica una tarifa única.",
+  },
+  {
+    question: "¿Cómo se cargan los destinatarios?",
+    answer:
+      "En el panel de empresas las campañas aceptan archivos CSV con las columnas que pida el canal y la plantilla (por ejemplo teléfono, nombre y variables del mensaje). No anunciamos aquí una API pública de clientes: el mecanismo disponible para las campañas es la carga de archivos y el panel.",
+  },
+  {
+    question: "¿WhatsApp masivo es un chat libre?",
+    answer:
+      "No. WhatsApp Business Platform usa plantillas aprobadas por Meta, con reglas y cupos del proveedor. Notificas envía esas plantillas, registra lo despachado y anota lo que Meta reporta.",
+  },
+  {
+    question: "¿Queda evidencia de cada destinatario?",
+    answer:
+      "Cada fila se trata como un envío individual: contenido personalizado, destino, estados y eventos. Eso permite reportes y constancias por comunicación, no solo un total de campaña.",
+  },
+  {
+    question: "¿El envío masivo cumple cualquier requisito legal?",
+    answer:
+      "No. Escalar un canal no cambia la forma que una norma o un contrato puedan exigir. La evidencia técnica de cada envío es un plano distinto al cumplimiento jurídico del acto.",
+  },
+];
+
+export default function NotificacionesMasivasPage() {
+  return (
+    <PublicArticle
+      title={page.title}
+      description={page.description}
+      path={page.path}
+      lead="Las empresas pueden enviar comunicaciones digitales masivas por WhatsApp y email con seguimiento por destinatario, siempre que el canal y la base lo permitan. Notificas registra esos envíos y sus eventos. El volumen no convierte cada mensaje en un acto formal equivalente a una carta documento."
+      faqs={faqs}
+      cta={{
+        title: "Campañas corporativas",
+        description:
+          "Contanos volumen, canal y tipo de comunicación. Las campañas de alto volumen se implementan previa evaluación técnica y cotización.",
+        primaryHref: "/#cotizacion",
+        primaryLabel: "Solicitar cotización",
+        secondaryHref: "/login?next=/empresa",
+        secondaryLabel: "Acceso empresas",
+      }}
+    >
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Para quién está pensado</h2>
+      <p>
+        El envío uno a uno alcanza cuando hay pocos destinatarios. Cuando hay cientos o miles —
+        clientes, usuarios, afiliados, deudores, asegurados — hace falta procesar una base,
+        personalizar cada fila, respetar los límites del canal y dejar rastro de cada comunicación.
+      </p>
+      <p>Eso aparece, entre otros, en:</p>
+      <ul className="list-disc space-y-1 pl-5">
+        <li>fintech y entidades financieras;</li>
+        <li>bancos y compañías de crédito;</li>
+        <li>retailers y ecommerce;</li>
+        <li>seguros;</li>
+        <li>telecomunicaciones y empresas de servicios;</li>
+        <li>cobranzas y estudios;</li>
+        <li>plataformas digitales con bases de usuarios.</li>
+      </ul>
+      <p>
+        Los usos concretos van desde avisos de vencimiento y gestión de mora hasta comunicaciones
+        contractuales, cortes de servicio o novedades operativas. Cada rubro tiene normas propias;
+        este artículo describe el plano técnico del envío, no el régimen de cada industria.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">CSV, panel y lo que no anunciamos</h2>
+      <p>
+        En el panel de empresas, las campañas permiten cargar destinatarios mediante CSV. El archivo
+        debe traer las columnas que el canal y la plantilla exijan —identidad de contacto y
+        variables del mensaje—. Un CSV mal separado o incompleto no se procesa. Ese flujo está
+        disponible hoy para las organizaciones que operan campañas.
+      </p>
+      <p>
+        No describimos aquí una API pública de integración para clientes finales porque no es un
+        producto documentado en este sitio. Si una organización necesita una integración a medida,
+        eso se evalúa en la cotización; no se presenta como funcionalidad ya publicada.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Canales y evidencia</h2>
+      <p>
+        WhatsApp usa plantillas de Meta, envío progresivo según capacidad, y registro de lo que el
+        proveedor informe sobre entrega o lectura. El correo anota si el servidor aceptó el envío,
+        si llegó un rebote y si la persona abrió el enlace de lectura cuando ese evento ocurre. SMTP
+        aceptado no significa que el mail haya ingresado a la bandeja. Más detalle en{" "}
+        <Link href="/notificacion-whatsapp" className="text-primary underline-offset-4 hover:underline">
+          notificaciones por WhatsApp
+        </Link>{" "}
+        y en{" "}
+        <Link href="/email-certificado" className="text-primary underline-offset-4 hover:underline">
+          email verificable
+        </Link>
+        .
+      </p>
+      <p>
+        La certificación tecnológica consiste en huellas de contenido y eventos, que pueden
+        anclarse en Polygon. No es un aval de un organismo público.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Cómo se cotiza</h2>
+      <p>
+        Los envíos individuales del panel personal usan créditos. Las campañas de volumen se
+        evalúan caso por caso: calidad de la base, plantilla, ritmo, canal y reportes. No
+        publicamos tarifas de Meta ni un precio único de campaña.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Límites</h2>
+      <p>
+        Meta puede limitar plantillas, números o velocidad. Una base con teléfonos inválidos produce
+        fallas de entrega, no “notificaciones jurídicas”. El envío masivo no sustituye formas
+        legales puntuales ni dispensa de políticas de privacidad y de consentimiento que correspondan
+        a cada organización.
+      </p>
+      <p>
+        Para el marco del producto frente a la carta documento, ver{" "}
+        <Link
+          href="/notificacion-digital-vs-carta-documento"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificación digital y carta documento
+        </Link>
+        . El enfoque operativo de WhatsApp Business también está en{" "}
+        <Link
+          href="/notificaciones-whatsapp-empresas"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificaciones por WhatsApp para empresas
+        </Link>
+        .
+      </p>
+    </PublicArticle>
+  );
+}

--- a/src/app/notificaciones-whatsapp-empresas/page.tsx
+++ b/src/app/notificaciones-whatsapp-empresas/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = createPageMetadata({
   title: page.title,
   description: page.description,
   path: page.path,
+  ogType: "article",
   keywords: [
     "notificaciones WhatsApp empresas",
     "campañas WhatsApp Business",
@@ -53,6 +54,13 @@ export default function WhatsAppEmpresasPage() {
         Pedí una cotización desde el{" "}
         <Link href="/#empresas" className="text-primary underline-offset-4 hover:underline">
           formulario para empresas
+        </Link>
+        , leé{" "}
+        <Link
+          href="/notificaciones-masivas-empresas"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificaciones digitales masivas
         </Link>{" "}
         o creá una{" "}
         <Link href="/signup" className="text-primary underline-offset-4 hover:underline">

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -43,7 +43,7 @@ export default function OpenGraphImage() {
               maxWidth: 900,
             }}
           >
-            Notificaciones fehacientes digitales
+            Notificaciones digitales verificables
           </div>
           <div
             style={{
@@ -53,8 +53,7 @@ export default function OpenGraphImage() {
               lineHeight: 1.35,
             }}
           >
-            Certificá envío, recepción y lectura en blockchain Polygon. Valor
-            probatorio, más económico que una carta documento.
+            {SITE_TAGLINE}. Evidencia técnica y trazabilidad en Argentina.
           </div>
         </div>
         <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,6 @@ import {
   ArrowRight,
   Mail,
   Send,
-  Phone,
   Search,
   MessageCircle,
   FileText,
@@ -19,21 +18,24 @@ import {
   Inbox,
 } from 'lucide-react';
 import { FaqSection } from '@/components/faq-section';
-import { FooterContactForm, QuoteContactForm } from '@/components/footer-contact-form';
+import { QuoteContactForm } from '@/components/footer-contact-form';
 import { LandingHeader } from '@/components/landing-header';
 import { JsonLd } from '@/components/json-ld';
+import { PublicFooter } from '@/components/public-footer';
+import { GEO_LANDING_PAGES } from '@/lib/public-resources';
 import { createPageMetadata, SEO_GUIDE_PAGES } from '@/lib/seo';
 import {
   faqPageJsonLd,
   organizationJsonLd,
   serviceJsonLd,
+  softwareApplicationJsonLd,
   websiteJsonLd,
 } from '@/lib/structured-data';
 
 const HOME_TITLE =
-  'Notificas | Notificaciones fehacientes digitales certificadas en blockchain';
+  'Notificas | Comunicaciones digitales verificables por WhatsApp y email';
 const HOME_DESCRIPTION =
-  'Enviá un mensaje y dejá constancia de qué salió, a quién y cuándo. El certificado de lectura se emite una sola vez. Campañas de volumen por WhatsApp y correo, previa cotización.';
+  'Plataforma argentina para comunicaciones digitales verificables por WhatsApp y email. Evidencia técnica, trazabilidad de eventos y verificación pública de constancias.';
 
 export const metadata: Metadata = {
   ...createPageMetadata({
@@ -152,6 +154,7 @@ export default function LandingPage() {
     <div className="brand-canvas flex min-h-screen flex-col text-foreground">
       <JsonLd data={organizationJsonLd()} />
       <JsonLd data={websiteJsonLd()} />
+      <JsonLd data={softwareApplicationJsonLd()} />
       <JsonLd data={serviceJsonLd()} />
       <JsonLd data={faqPageJsonLd()} />
       <LandingHeader />
@@ -161,10 +164,10 @@ export default function LandingPage() {
           <div className="container grid items-start gap-12 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] lg:gap-16">
             <div className="landing-hero-copy max-w-2xl">
               <h1 className="mb-5 text-balance text-3xl font-bold tracking-tight sm:text-4xl md:text-[2.75rem] md:leading-tight">
-                Notificas: notificaciones digitales con constancia de envío y lectura
+                Notificas: comunicaciones digitales verificables por WhatsApp y email
               </h1>
               <p className="landing-hero-muted mb-8 max-w-[65ch] text-pretty text-base leading-relaxed sm:text-lg">
-                Notificá por WhatsApp o correo y obtené un rastro comprobable. Más rápido y económico que una carta documento, con PDF para tu expediente.
+                Plataforma argentina para empresas y profesionales que necesitan generar y preservar evidencia técnica sobre las distintas etapas de una comunicación. Más rápido y económico que una carta documento en la operación cotidiana; no la reemplaza si la ley pide esa forma.
               </p>
               <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
                 <Button size="lg" className="w-full sm:w-auto" asChild>
@@ -195,6 +198,53 @@ export default function LandingPage() {
                 </li>
               ))}
             </ol>
+          </div>
+        </section>
+
+        <section id="que-es" className="px-4 py-16 sm:py-20 md:py-24">
+          <div className="container max-w-3xl space-y-8">
+            <div>
+              <h2 className="mb-4 text-3xl font-bold tracking-tight md:text-4xl">Qué es Notificas</h2>
+              <p className="max-w-[70ch] leading-relaxed text-muted-foreground">
+                Notificas es una plataforma de comunicaciones digitales verificables por WhatsApp y
+                email. Permite a empresas y profesionales generar y preservar evidencia técnica sobre
+                las distintas etapas de una comunicación: qué se envió, a quién, cuándo, y los eventos
+                posteriores que el canal informe.
+              </p>
+            </div>
+            <div className="grid gap-8 sm:grid-cols-2">
+              <article>
+                <h3 className="text-lg font-semibold">Qué hace</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
+                  Envía el mensaje, conserva el contenido, registra estados (aceptación, rebote,
+                  entrega o lectura cuando el canal los informa) y deja una huella verificable.
+                </p>
+              </article>
+              <article>
+                <h3 className="text-lg font-semibold">Para quién</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
+                  Profesionales que envían uno a uno, y empresas que necesitan campañas de volumen
+                  para cobranza, avisos de servicio, ecommerce, seguros o plataformas digitales.
+                </p>
+              </article>
+              <article>
+                <h3 className="text-lg font-semibold">Canales</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
+                  WhatsApp Business Platform (plantillas aprobadas por Meta) y correo electrónico.
+                  Cada canal deja su propio rastro; no se fusionan en un solo hecho.
+                </p>
+              </article>
+              <article>
+                <h3 className="text-lg font-semibold">Cómo verificar</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
+                  Cualquiera puede comprobar una constancia PDF o un identificador en{' '}
+                  <Link href="/verify" className="text-primary underline-offset-4 hover:underline">
+                    notificas.com.ar/verify
+                  </Link>
+                  , sin iniciar sesión.
+                </p>
+              </article>
+            </div>
           </div>
         </section>
 
@@ -336,10 +386,29 @@ export default function LandingPage() {
             </div>
         </section>
 
-        <section id="guias" className="px-4 pb-16 sm:pb-20">
+        <section id="guias" className="scroll-mt-24 px-4 pb-16 sm:pb-20">
           <div className="container max-w-4xl">
-            <h2 className="mb-6 text-2xl font-bold tracking-tight md:text-3xl">Guías</h2>
+            <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <h2 className="text-2xl font-bold tracking-tight md:text-3xl">Recursos</h2>
+              <Link
+                href="/recursos"
+                className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+              >
+                Ver todos los recursos
+              </Link>
+            </div>
             <ul className="grid gap-4 sm:grid-cols-2">
+              {GEO_LANDING_PAGES.map((guide) => (
+                <li key={guide.path}>
+                  <Link
+                    href={guide.path}
+                    className="block rounded-lg border border-border bg-background/60 p-4 transition-colors hover:bg-muted/60"
+                  >
+                    <span className="font-semibold leading-snug">{guide.title}</span>
+                    <span className="mt-1 block text-sm text-muted-foreground">{guide.blurb}</span>
+                  </Link>
+                </li>
+              ))}
               {SEO_GUIDE_PAGES.map((guide) => (
                 <li key={guide.path}>
                   <Link
@@ -357,56 +426,7 @@ export default function LandingPage() {
 
         <FaqSection />
       </main>
-
-      <footer className="bg-foreground text-background">
-        <div className="container grid grid-cols-1 gap-10 px-4 py-12 md:grid-cols-3 md:gap-8 md:px-6 md:py-14">
-            <div>
-                <h3 className="mb-4 text-lg font-bold">Notificas</h3>
-                <p className="text-sm text-background/80">Colon 12, primer piso - San Nicolás de los Arroyos</p>
-                <p className="text-sm text-background/80">Buenos Aires - Argentina</p>
-                <div className="mt-5 space-y-2 text-sm">
-                    <Link href="/notificacion-fehaciente-digital" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">Notificación fehaciente digital</Link>
-                    <Link href="/carta-documento-digital" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">Carta documento digital</Link>
-                    <Link href="/notificaciones-whatsapp-empresas" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">WhatsApp para empresas</Link>
-                    <Link href="/como-verificar-certificado" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">Cómo verificar un certificado</Link>
-                    <Link href="/consumidores" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">Defensa del Consumidor</Link>
-                    <Link href="/terminos" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">Términos y Condiciones</Link>
-                    <Link href="/privacidad" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">Política de Privacidad</Link>
-                    <Link href="/arrepentimiento" className="block text-background/80 underline-offset-4 hover:text-background hover:underline">Derecho de Arrepentimiento</Link>
-                </div>
-            </div>
-            <div id="contacto" className="scroll-mt-24">
-                <h3 className="mb-4 text-lg font-bold">Contáctenos</h3>
-                <FooterContactForm />
-            </div>
-             <div>
-                <h3 className="mb-4 text-lg font-bold">Contacto Directo</h3>
-                <div className="space-y-2 text-sm">
-                    <p className="flex items-center gap-2 text-background/80">
-                        <Mail className="h-4 w-4" aria-hidden />
-                        <span>contacto@notificas.com</span>
-                    </p>
-                    <p className="flex items-center gap-2 text-background/80">
-                        <Phone className="h-4 w-4" aria-hidden />
-                        <span>+54 93364645357</span>
-                    </p>
-                </div>
-            </div>
-        </div>
-        <div className="border-t border-background/20">
-            <div className="container space-y-2 px-4 py-4 pb-[max(1rem,env(safe-area-inset-bottom))] text-center text-sm text-background/80 md:px-6">
-                <p>Copyright © 2026 | Notificas SRL</p>
-                <p>
-                  <Link
-                    href="/login?next=/empresa"
-                    className="text-xs leading-tight text-background/55 transition-colors hover:text-background/80"
-                  >
-                    Acceso empresas
-                  </Link>
-                </p>
-            </div>
-        </div>
-      </footer>
+      <PublicFooter variant="full" />
     </div>
   );
 }

--- a/src/app/recursos/page.tsx
+++ b/src/app/recursos/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { LandingHeader } from "@/components/landing-header";
+import { JsonLd } from "@/components/json-ld";
+import { PublicFooter } from "@/components/public-footer";
+import { Breadcrumbs } from "@/components/seo/breadcrumbs";
+import {
+  GEO_LANDING_PAGES,
+  RESOURCE_HUB,
+  SEO_GUIDE_PAGES,
+} from "@/lib/public-resources";
+import { createPageMetadata } from "@/lib/seo";
+import { breadcrumbJsonLd, organizationJsonLd } from "@/lib/structured-data";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Recursos",
+  description: RESOURCE_HUB.description,
+  path: RESOURCE_HUB.path,
+});
+
+const crumbs = [
+  { name: "Inicio", path: "/" },
+  { name: "Recursos", path: RESOURCE_HUB.path },
+];
+
+export default function RecursosPage() {
+  return (
+    <div className="brand-canvas flex min-h-screen flex-col text-foreground">
+      <JsonLd data={organizationJsonLd()} />
+      <JsonLd data={breadcrumbJsonLd(crumbs)} />
+      <LandingHeader />
+      <main className="flex-1 container max-w-3xl px-4 py-12">
+        <Breadcrumbs items={crumbs} />
+        <article className="space-y-8">
+          <header className="space-y-3">
+            <h1 className="text-3xl font-bold tracking-tight">{RESOURCE_HUB.title}</h1>
+            <p className="text-base leading-relaxed text-muted-foreground">
+              Artículos públicos sobre comunicaciones digitales verificables por WhatsApp y email.
+              Están pensados para responder preguntas reales, con lenguaje preciso sobre evidencia
+              técnica y sin afirmar equivalencias jurídicas que el producto no sostiene.
+            </p>
+          </header>
+
+          <section aria-labelledby="geo-heading">
+            <h2 id="geo-heading" className="mb-4 text-xl font-semibold">
+              Preguntas frecuentes de búsqueda
+            </h2>
+            <ul className="grid gap-4">
+              {GEO_LANDING_PAGES.map((page) => (
+                <li key={page.path}>
+                  <Link
+                    href={page.path}
+                    className="block rounded-lg border border-border bg-background/60 p-4 transition-colors hover:bg-muted/60"
+                  >
+                    <span className="font-semibold leading-snug">{page.title}</span>
+                    <span className="mt-1 block text-sm text-muted-foreground">{page.blurb}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section aria-labelledby="guias-heading">
+            <h2 id="guias-heading" className="mb-4 text-xl font-semibold">
+              Guías del producto
+            </h2>
+            <ul className="grid gap-4">
+              {SEO_GUIDE_PAGES.map((page) => (
+                <li key={page.path}>
+                  <Link
+                    href={page.path}
+                    className="block rounded-lg border border-border bg-background/60 p-4 transition-colors hover:bg-muted/60"
+                  >
+                    <span className="font-semibold leading-snug">{page.title}</span>
+                    <span className="mt-1 block text-sm text-muted-foreground">{page.blurb}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <p className="text-sm text-muted-foreground">
+            Para comprobar una constancia ya emitida, usá{" "}
+            <Link href="/verify" className="text-primary underline-offset-4 hover:underline">
+              Verificar
+            </Link>
+            . Para enviar,{" "}
+            <Link href="/signup" className="text-primary underline-offset-4 hover:underline">
+              registrate
+            </Link>
+            .
+          </p>
+        </article>
+      </main>
+      <PublicFooter />
+    </div>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,12 @@
 import type { MetadataRoute } from "next";
+import {
+  PRIVATE_PATH_PREFIXES,
+  SEARCH_RETRIEVAL_USER_AGENTS,
+  TRAINING_USER_AGENTS,
+} from "@/lib/robots-policy";
 import { SITE_URL } from "@/lib/seo";
+
+const publicDisallow = [...PRIVATE_PATH_PREFIXES];
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -7,22 +14,17 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: [
-          "/api/",
-          "/admin/",
-          "/dashboard/",
-          "/empresa/",
-          "/cuenta/",
-          "/reader/",
-          "/pdf-viewer/",
-          "/process-payment/",
-          "/email-preview/",
-          "/test-firestore/",
-          "/test-polygon/",
-          "/test-reader/",
-          "/linkRedirect",
-        ],
+        disallow: publicDisallow,
       },
+      ...SEARCH_RETRIEVAL_USER_AGENTS.map((userAgent) => ({
+        userAgent,
+        allow: "/",
+        disallow: publicDisallow,
+      })),
+      ...TRAINING_USER_AGENTS.map((userAgent) => ({
+        userAgent,
+        disallow: "/",
+      })),
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,
     host: SITE_URL,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,11 @@
 import type { MetadataRoute } from "next";
-import { SEO_GUIDE_PAGES, SITE_URL, SITEMAP_LASTMOD } from "@/lib/seo";
+import {
+  GEO_LANDING_PAGES,
+  LEGAL_PUBLIC_PAGES,
+  RESOURCE_HUB,
+  SEO_GUIDE_PAGES,
+} from "@/lib/public-resources";
+import { SITE_URL, SITEMAP_LASTMOD } from "@/lib/seo";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const routes: Array<{
@@ -10,15 +16,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/", changeFrequency: "weekly", priority: 1 },
     { path: "/verify", changeFrequency: "monthly", priority: 0.9 },
     { path: "/signup", changeFrequency: "monthly", priority: 0.85 },
+    {
+      path: RESOURCE_HUB.path,
+      changeFrequency: "monthly",
+      priority: 0.75,
+    },
+    ...GEO_LANDING_PAGES.map((page) => ({
+      path: page.path,
+      changeFrequency: "monthly" as const,
+      priority: 0.85,
+    })),
     ...SEO_GUIDE_PAGES.map((page) => ({
       path: page.path,
       changeFrequency: "monthly" as const,
       priority: 0.8,
     })),
-    { path: "/consumidores", changeFrequency: "yearly", priority: 0.5 },
-    { path: "/terminos", changeFrequency: "yearly", priority: 0.4 },
-    { path: "/privacidad", changeFrequency: "yearly", priority: 0.4 },
-    { path: "/arrepentimiento", changeFrequency: "yearly", priority: 0.4 },
+    ...LEGAL_PUBLIC_PAGES.map((page) => ({
+      path: page.path,
+      changeFrequency: "yearly" as const,
+      priority: 0.4,
+    })),
   ];
 
   return routes.map((route) => ({

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -43,7 +43,7 @@ export default function TwitterImage() {
               maxWidth: 900,
             }}
           >
-            Notificaciones fehacientes digitales
+            Notificaciones digitales verificables
           </div>
           <div
             style={{
@@ -53,8 +53,7 @@ export default function TwitterImage() {
               lineHeight: 1.35,
             }}
           >
-            Certificá envío, recepción y lectura en blockchain Polygon. Valor
-            probatorio, más económico que una carta documento.
+            {SITE_TAGLINE}. Evidencia técnica y trazabilidad en Argentina.
           </div>
         </div>
         <div

--- a/src/app/whatsapp-como-prueba/page.tsx
+++ b/src/app/whatsapp-como-prueba/page.tsx
@@ -1,0 +1,145 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { PublicArticle } from "@/components/public-article";
+import { createPageMetadata, getGeoLanding } from "@/lib/seo";
+
+const page = getGeoLanding("/whatsapp-como-prueba");
+
+export const metadata: Metadata = createPageMetadata({
+  title: "WhatsApp como prueba: evidencia y trazabilidad",
+  description: page.description,
+  path: page.path,
+  keywords: page.keywords ? [...page.keywords] : undefined,
+  ogType: "article",
+});
+
+const faqs = [
+  {
+    question: "¿Un WhatsApp sirve como prueba?",
+    answer:
+      "Puede constituir un elemento probatorio sobre una comunicación, si se logra acreditar contenido, partes, fecha y, cuando sea posible, integridad. No hay una respuesta única: el peso de ese elemento lo determina quien deba valorarlo, según el caso y las reglas aplicables.",
+  },
+  {
+    question: "¿Qué conviene conservar además del texto?",
+    answer:
+      "Remitente, destinatario, fecha y hora, identificadores del mensaje, eventos de entrega y de lectura cuando existan, y un mecanismo para verificar que el conjunto no fue modificado. El texto suelto, sin contexto ni integridad, suele ser más débil.",
+  },
+  {
+    question: "¿Sirve un pantallazo?",
+    answer:
+      "Un pantallazo puede ilustrar un contenido, pero no demuestra por sí mismo que no fue recortado, reenviado o editado, ni reconstruye la secuencia de entrega. Conviene complementarlo con registros técnicos del envío.",
+  },
+  {
+    question: "¿Qué pasa si el chat se borra después?",
+    answer:
+      "Si la única copia estaba en el teléfono, puede perderse. Por eso importa conservar el contenido y los eventos fuera del dispositivo, con una huella que permita detectar alteraciones posteriores.",
+  },
+  {
+    question: "¿Notificas transforma un WhatsApp en prueba plena?",
+    answer:
+      "No. Notificas preserva evidencia técnica y trazabilidad de eventos. No califica el valor legal de esa evidencia ni reemplaza pericias, oficios u otros medios que un proceso pueda requerir.",
+  },
+];
+
+export default function WhatsAppComoPruebaPage() {
+  return (
+    <PublicArticle
+      title={page.title}
+      description={page.description}
+      path={page.path}
+      lead="Si un mensaje de WhatsApp puede llegar a discutirse, conviene conservar no solo el texto, sino también quién lo envió, a quién, cuándo, cómo se identificó el mensaje y qué eventos de entrega o lectura quedaron registrados. Esa evidencia es un elemento técnico; su suficiencia jurídica se valora en cada caso."
+      faqs={faqs}
+    >
+      <h2 className="pt-2 text-xl font-semibold text-foreground">
+        Por qué el contenido solo no alcanza
+      </h2>
+      <p>
+        Un mensaje de WhatsApp es fácil de copiar y de sacar de contexto. Quien lo exhibe más
+        adelante suele necesitar mostrar, con el mayor rigor posible, que ese texto es el que se
+        envió, a ese destinatario, en esa fecha, y que no fue reescrito. Esa es una cuestión de
+        evidencia, no de eslóganes sobre “fehaciencia”.
+      </p>
+      <p>
+        Este artículo no asesora sobre el resultado de un juicio. Describe qué datos suelen ser
+        útiles para reconstruir una comunicación y dónde aparecen sus límites.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Elementos que conviene registrar</h2>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Contenido</h3>
+      <p>
+        El texto efectivamente despachado, no un resumen posterior. En envíos empresariales con
+        plantillas, el contenido relevante es la plantilla aprobada más los datos de esa persona. Si
+        había encabezado, pie o botones, también forman parte de lo enviado.
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Remitente y destinatario</h3>
+      <p>
+        Qué número o cuenta envió el mensaje y a qué número se dirigió. Identificar el teléfono no
+        equivale, por sí solo, a identificar a una persona determinada: esa correspondencia puede
+        requerir otros elementos (contratos, padrones internos, reconocimientos, etc.).
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Fecha y hora</h3>
+      <p>
+        El sello temporal del despacho, y el de los eventos posteriores si el canal los informa.
+        Conviene conservar la zona horaria o el criterio de registro para evitar ambigüedades.
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Identificación de mensajes</h3>
+      <p>
+        Los proveedores suelen asignar un identificador al mensaje (por ejemplo, un WAMID en
+        WhatsApp Business). Ese dato ayuda a distinguir un envío de otro y a correlacionar eventos
+        de entrega o lectura con el texto concreto.
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Entrega y lectura</h3>
+      <p>
+        La entrega, cuando se informa, apunta a que el aviso llegó al dispositivo o a la cuenta. La
+        lectura, cuando existe, es un evento posterior y distinto. Ninguno de los dos prueba que la
+        persona haya aceptado el contenido, ni que haya leído cada párrafo.
+      </p>
+
+      <h3 className="pt-1 text-lg font-semibold text-foreground">Integridad, conservación y trazabilidad</h3>
+      <p>
+        Integridad significa poder detectar si el registro fue alterado. Conservación significa
+        guardarlo el tiempo necesario fuera del teléfono. Trazabilidad significa poder ordenar los
+        eventos: envío, entrega, lectura, clicks a un enlace, emisión de una constancia. Un archivo
+        que no se puede verificar más tarde pierde utilidad.
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Cómo interviene Notificas</h2>
+      <p>
+        Notificas registra el contenido despachado por WhatsApp Business, los destinos, los eventos
+        que Meta reporta y una huella de ese conjunto. Esa huella puede anclarse en Polygon. Las
+        constancias PDF pueden contrastarse después en{" "}
+        <Link href="/verify" className="text-primary underline-offset-4 hover:underline">
+          notificas.com.ar/verify
+        </Link>
+        . El detalle operativo del canal está en{" "}
+        <Link href="/notificacion-whatsapp" className="text-primary underline-offset-4 hover:underline">
+          notificaciones por WhatsApp
+        </Link>
+        .
+      </p>
+
+      <h2 className="pt-2 text-xl font-semibold text-foreground">Límites</h2>
+      <p>
+        Conservar evidencia no decide el conflicto. Un juez, un mediador o un organismo pueden
+        pedir otros recaudos, restar valor a un medio o exigir una forma distinta. WhatsApp, además,
+        no identifica por sí mismo al titular de la línea con certeza absoluta.
+      </p>
+      <p>
+        Si el acto requiere una forma legal determinada, la evidencia digital no la reemplaza. Ver{" "}
+        <Link
+          href="/notificacion-digital-vs-carta-documento"
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          notificación digital y carta documento
+        </Link>
+        .
+      </p>
+    </PublicArticle>
+  );
+}

--- a/src/components/ai-referral-tracker.tsx
+++ b/src/components/ai-referral-tracker.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { matchAiReferrerHost, utmParamsFromSearch } from "@/lib/ai-referrers";
+
+const SESSION_UTM_KEY = "notificas_utm";
+const SESSION_AI_KEY = "notificas_ai_ref";
+
+/**
+ * Conserva UTM y referers de asistentes de IA y los envía a Firebase Analytics.
+ * Carga Analytics en diferido para no bloquear el HTML público.
+ */
+export function AiReferralTracker() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const utm = utmParamsFromSearch(window.location.search);
+    if (Object.keys(utm).length) {
+      try {
+        sessionStorage.setItem(SESSION_UTM_KEY, JSON.stringify(utm));
+      } catch {
+        /* ignore quota */
+      }
+    }
+
+    let aiSource: string | null = null;
+    try {
+      const referrerHost = document.referrer ? new URL(document.referrer).hostname : "";
+      aiSource = referrerHost ? matchAiReferrerHost(referrerHost) : null;
+      if (aiSource) sessionStorage.setItem(SESSION_AI_KEY, aiSource);
+      else aiSource = sessionStorage.getItem(SESSION_AI_KEY);
+    } catch {
+      aiSource = null;
+    }
+
+    let storedUtm: Record<string, string> = utm;
+    try {
+      if (!Object.keys(storedUtm).length) {
+        storedUtm = JSON.parse(sessionStorage.getItem(SESSION_UTM_KEY) || "{}") as Record<
+          string,
+          string
+        >;
+      }
+    } catch {
+      storedUtm = utm;
+    }
+
+    if (!aiSource && !Object.keys(storedUtm).length) return;
+
+    void import("@/lib/firebase")
+      .then(async ({ app }) => {
+        const { getAnalytics, isSupported, logEvent } = await import("firebase/analytics");
+        if (!(await isSupported())) return;
+        const analytics = getAnalytics(app);
+        const params: Record<string, string> = {
+          page_path: window.location.pathname,
+          ...storedUtm,
+        };
+        if (aiSource) params.ai_source = aiSource;
+        logEvent(analytics, aiSource ? "ai_referral" : "campaign_hit", params);
+      })
+      .catch(() => {
+        /* Analytics opcional en páginas públicas */
+      });
+  }, []);
+
+  return null;
+}

--- a/src/components/landing-header.tsx
+++ b/src/components/landing-header.tsx
@@ -18,7 +18,7 @@ import {
 const navLinks = [
   { href: "/#ventajas", label: "Ventajas" },
   { href: "/#empresas", label: "Empresas" },
-  { href: "/#guias", label: "Guías" },
+  { href: "/recursos", label: "Recursos" },
   { href: "/verify", label: "Verificar certificado" },
   { href: "/#faq", label: "Preguntas frecuentes" },
 ];

--- a/src/components/public-article.tsx
+++ b/src/components/public-article.tsx
@@ -1,57 +1,84 @@
-import Link from "next/link";
 import type { ReactNode } from "react";
+import Link from "next/link";
 
 import { LandingHeader } from "@/components/landing-header";
 import { JsonLd } from "@/components/json-ld";
-import { SEO_GUIDE_PAGES } from "@/lib/seo";
-import { articleJsonLd, breadcrumbJsonLd } from "@/lib/structured-data";
+import { PublicFooter } from "@/components/public-footer";
+import { ArticleCta } from "@/components/seo/article-cta";
+import { ArticleFaq } from "@/components/seo/article-faq";
+import { ArticleHeader } from "@/components/seo/article-header";
+import { Breadcrumbs } from "@/components/seo/breadcrumbs";
+import { LegalDisclaimer } from "@/components/seo/legal-disclaimer";
+import { RelatedResources } from "@/components/seo/related-resources";
+import { RESOURCE_HUB } from "@/lib/public-resources";
+import {
+  articleJsonLd,
+  breadcrumbJsonLd,
+  faqPageJsonLd,
+  organizationJsonLd,
+  softwareApplicationJsonLd,
+} from "@/lib/structured-data";
 
 type PublicArticleProps = {
   title: string;
   description: string;
   path: string;
   children: ReactNode;
+  lead?: string;
+  faqs?: ReadonlyArray<{ question: string; answer: string }>;
+  cta?: {
+    title?: string;
+    description?: string;
+    primaryHref?: string;
+    primaryLabel?: string;
+    secondaryHref?: string;
+    secondaryLabel?: string;
+  };
 };
 
-export function PublicArticle({ title, description, path, children }: PublicArticleProps) {
-  const related = SEO_GUIDE_PAGES.filter((page) => page.path !== path);
+export function PublicArticle({
+  title,
+  description,
+  path,
+  children,
+  lead,
+  faqs,
+  cta,
+}: PublicArticleProps) {
+  const crumbs = [
+    { name: "Inicio", path: "/" },
+    { name: "Recursos", path: RESOURCE_HUB.path },
+    { name: title, path },
+  ];
 
   return (
     <div className="brand-canvas flex min-h-screen flex-col text-foreground">
+      <JsonLd data={organizationJsonLd()} />
+      <JsonLd data={softwareApplicationJsonLd()} />
       <JsonLd data={articleJsonLd({ title, description, path })} />
-      <JsonLd
-        data={breadcrumbJsonLd([
-          { name: "Inicio", path: "/" },
-          { name: title, path },
-        ])}
-      />
+      <JsonLd data={breadcrumbJsonLd(crumbs)} />
+      {faqs?.length ? <JsonLd data={faqPageJsonLd(faqs)} /> : null}
       <LandingHeader />
       <main className="flex-1 container max-w-3xl px-4 py-12">
-        <nav className="mb-6 text-sm text-muted-foreground">
-          <Link href="/" className="text-primary underline-offset-4 hover:underline">
-            Inicio
-          </Link>
-          <span aria-hidden> / </span>
-          <span className="text-foreground">{title}</span>
-        </nav>
+        <Breadcrumbs items={crumbs} />
         <article className="space-y-6 text-sm leading-relaxed text-foreground/90 sm:text-base">
-          <h1 className="text-3xl font-bold tracking-tight text-foreground">{title}</h1>
+          {lead ? (
+            <ArticleHeader title={title} lead={lead} />
+          ) : (
+            <>
+              <h1 className="text-3xl font-bold tracking-tight text-foreground">{title}</h1>
+              <p className="text-sm text-muted-foreground">
+                Última actualización: 27 de agosto de 2026 · Responsable: Notificas SRL
+              </p>
+            </>
+          )}
           {children}
+          {faqs?.length ? <ArticleFaq items={faqs} /> : null}
+          <LegalDisclaimer />
+          <ArticleCta {...cta} />
         </article>
 
-        <section className="mt-12 border-t pt-8">
-          <h2 className="mb-3 text-lg font-semibold">Seguir leyendo</h2>
-          <ul className="space-y-2 text-sm">
-            {related.map((page) => (
-              <li key={page.path}>
-                <Link href={page.path} className="text-primary underline-offset-4 hover:underline">
-                  {page.title}
-                </Link>
-                <span className="text-muted-foreground"> — {page.blurb}</span>
-              </li>
-            ))}
-          </ul>
-        </section>
+        <RelatedResources currentPath={path} />
 
         <p className="mt-10 text-sm text-muted-foreground">
           <Link href="/" className="text-primary hover:underline">
@@ -59,6 +86,7 @@ export function PublicArticle({ title, description, path, children }: PublicArti
           </Link>
         </p>
       </main>
+      <PublicFooter />
     </div>
   );
 }

--- a/src/components/public-footer.tsx
+++ b/src/components/public-footer.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Mail, Phone } from "lucide-react";
+
+import { FooterContactForm } from "@/components/footer-contact-form";
+import { LEGAL_PUBLIC_PAGES, RESOURCE_HUB } from "@/lib/public-resources";
+import { SITE_CONTACT } from "@/lib/seo";
+
+function FooterLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="block text-background/80 underline-offset-4 hover:text-background hover:underline"
+    >
+      {children}
+    </Link>
+  );
+}
+
+export function PublicFooter({ variant = "compact" }: { variant?: "full" | "compact" }) {
+  return (
+    <footer className="bg-foreground text-background">
+      <div className="container grid grid-cols-1 gap-10 px-4 py-12 md:grid-cols-3 md:gap-8 md:px-6 md:py-14">
+        <div>
+          <h2 className="mb-4 text-lg font-bold">Notificas</h2>
+          <p className="text-sm text-background/80">
+            {SITE_CONTACT.address.streetAddress} - {SITE_CONTACT.address.addressLocality}
+          </p>
+          <p className="text-sm text-background/80">
+            {SITE_CONTACT.address.addressRegion} - Argentina
+          </p>
+          <nav className="mt-5 space-y-2 text-sm" aria-label="Recursos">
+            <p className="font-semibold text-background">Recursos</p>
+            <FooterLink href={RESOURCE_HUB.path}>Todos los recursos</FooterLink>
+            <FooterLink href="/notificacion-whatsapp">Notificaciones por WhatsApp</FooterLink>
+            <FooterLink href="/whatsapp-como-prueba">WhatsApp como prueba</FooterLink>
+            <FooterLink href="/intimacion-deuda-whatsapp">Intimación de deuda</FooterLink>
+            <FooterLink href="/notificaciones-masivas-empresas">Notificaciones masivas</FooterLink>
+            <FooterLink href="/email-certificado">Email verificable</FooterLink>
+            <FooterLink href="/notificacion-digital-vs-carta-documento">
+              Digital vs. carta documento
+            </FooterLink>
+            <FooterLink href="/notificacion-fehaciente-digital">Notificación fehaciente digital</FooterLink>
+            <FooterLink href="/carta-documento-digital">Carta documento digital</FooterLink>
+            <FooterLink href="/notificaciones-whatsapp-empresas">WhatsApp para empresas</FooterLink>
+            <FooterLink href="/como-verificar-certificado">Cómo verificar un certificado</FooterLink>
+            <FooterLink href="/verify">Verificar una constancia</FooterLink>
+            {LEGAL_PUBLIC_PAGES.map((page) => (
+              <FooterLink key={page.path} href={page.path}>
+                {page.title}
+              </FooterLink>
+            ))}
+          </nav>
+        </div>
+        {variant === "full" ? (
+          <div id="contacto" className="scroll-mt-24">
+            <h2 className="mb-4 text-lg font-bold">Contáctenos</h2>
+            <FooterContactForm />
+          </div>
+        ) : (
+          <div id="contacto" className="scroll-mt-24">
+            <h2 className="mb-4 text-lg font-bold">Contáctenos</h2>
+            <p className="text-sm leading-relaxed text-background/80">
+              Escribinos a {SITE_CONTACT.email} o usá el formulario de la página de inicio.
+            </p>
+            <FooterLink href="/#contacto">Ir al formulario de contacto</FooterLink>
+          </div>
+        )}
+        <div>
+          <h2 className="mb-4 text-lg font-bold">Contacto Directo</h2>
+          <div className="space-y-2 text-sm">
+            <p className="flex items-center gap-2 text-background/80">
+              <Mail className="h-4 w-4" aria-hidden />
+              <a href={`mailto:${SITE_CONTACT.email}`} className="underline-offset-4 hover:underline">
+                {SITE_CONTACT.email}
+              </a>
+            </p>
+            <p className="flex items-center gap-2 text-background/80">
+              <Phone className="h-4 w-4" aria-hidden />
+              <span>{SITE_CONTACT.phoneDisplay}</span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="border-t border-background/20">
+        <div className="container space-y-2 px-4 py-4 pb-[max(1rem,env(safe-area-inset-bottom))] text-center text-sm text-background/80 md:px-6">
+          <p>Copyright © 2026 | Notificas SRL</p>
+          <p>
+            <Link
+              href="/login?next=/empresa"
+              className="text-xs leading-tight text-background/55 transition-colors hover:text-background/80"
+            >
+              Acceso empresas
+            </Link>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/seo/article-cta.tsx
+++ b/src/components/seo/article-cta.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+type ArticleCtaProps = {
+  title?: string;
+  description?: string;
+  primaryHref?: string;
+  primaryLabel?: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+};
+
+export function ArticleCta({
+  title = "Generar evidencia de una comunicación",
+  description = "Creá una cuenta para enviar por WhatsApp o email, o verificá una constancia ya emitida sin iniciar sesión.",
+  primaryHref = "/signup",
+  primaryLabel = "Crear cuenta",
+  secondaryHref = "/verify",
+  secondaryLabel = "Verificar una constancia",
+}: ArticleCtaProps) {
+  return (
+    <section className="rounded-lg border border-border bg-background/60 p-6" aria-labelledby="cta-heading">
+      <h2 id="cta-heading" className="text-xl font-semibold text-foreground">
+        {title}
+      </h2>
+      <p className="mt-2 max-w-[65ch] text-sm leading-relaxed text-muted-foreground sm:text-base">
+        {description}
+      </p>
+      <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Button asChild>
+          <Link href={primaryHref}>{primaryLabel}</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href={secondaryHref}>{secondaryLabel}</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/seo/article-faq.tsx
+++ b/src/components/seo/article-faq.tsx
@@ -1,0 +1,31 @@
+type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+export function ArticleFaq({ items }: { items: readonly FaqItem[] }) {
+  if (!items.length) return null;
+
+  return (
+    <section className="space-y-4" aria-labelledby="faq-heading">
+      <h2 id="faq-heading" className="pt-2 text-xl font-semibold text-foreground">
+        Preguntas frecuentes
+      </h2>
+      <div className="space-y-3">
+        {items.map((item) => (
+          <details
+            key={item.question}
+            className="rounded-lg border border-border bg-background/60 px-4 py-3"
+          >
+            <summary className="cursor-pointer text-sm font-medium text-foreground sm:text-base">
+              {item.question}
+            </summary>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground sm:text-base">
+              {item.answer}
+            </p>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/seo/article-header.tsx
+++ b/src/components/seo/article-header.tsx
@@ -1,0 +1,29 @@
+import { CONTENT_EDITOR, CONTENT_UPDATED_LABEL } from "@/lib/seo";
+
+type ArticleHeaderProps = {
+  title: string;
+  lead: string;
+  updatedLabel?: string;
+  editor?: string;
+};
+
+export function ArticleHeader({
+  title,
+  lead,
+  updatedLabel = CONTENT_UPDATED_LABEL,
+  editor = CONTENT_EDITOR,
+}: ArticleHeaderProps) {
+  return (
+    <header className="space-y-4">
+      <h1 className="text-3xl font-bold tracking-tight text-foreground">{title}</h1>
+      <p className="text-sm text-muted-foreground">
+        Última actualización: {updatedLabel}
+        <span aria-hidden> · </span>
+        Responsable: {editor}
+      </p>
+      <p className="rounded-lg border border-border bg-muted/40 p-4 text-base leading-relaxed text-foreground">
+        {lead}
+      </p>
+    </header>
+  );
+}

--- a/src/components/seo/breadcrumbs.tsx
+++ b/src/components/seo/breadcrumbs.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+export type BreadcrumbItem = {
+  name: string;
+  path?: string;
+};
+
+export function Breadcrumbs({ items }: { items: readonly BreadcrumbItem[] }) {
+  return (
+    <nav aria-label="Miga de pan" className="mb-6 text-sm text-muted-foreground">
+      <ol className="flex flex-wrap items-center gap-x-1 gap-y-1">
+        {items.map((item, index) => {
+          const last = index === items.length - 1;
+          return (
+            <li key={`${item.name}-${index}`} className="flex items-center gap-x-1">
+              {index > 0 ? <span aria-hidden> / </span> : null}
+              {last || !item.path ? (
+                <span className="text-foreground" aria-current={last ? "page" : undefined}>
+                  {item.name}
+                </span>
+              ) : (
+                <Link
+                  href={item.path}
+                  className={cn("text-primary underline-offset-4 hover:underline")}
+                >
+                  {item.name}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/seo/legal-disclaimer.tsx
+++ b/src/components/seo/legal-disclaimer.tsx
@@ -1,0 +1,17 @@
+export function LegalDisclaimer({ className }: { className?: string }) {
+  return (
+    <aside
+      className={className}
+      aria-label="Alcance jurídico de la información"
+    >
+      <p className="rounded-lg border border-border bg-muted/30 p-4 text-sm leading-relaxed text-muted-foreground">
+        El valor probatorio y la suficiencia de cada medio de comunicación dependen del caso
+        concreto, del contenido, de la normativa aplicable, de las formas que la ley o el contrato
+        exijan, y de la valoración que corresponda. Hay situaciones en las que una norma o un
+        contrato pueden exigir una forma determinada —por ejemplo, carta documento, notificación
+        judicial u otra—. Notificas no pretende sustituir automáticamente esos requisitos ni
+        garantiza un resultado jurídico.
+      </p>
+    </aside>
+  );
+}

--- a/src/components/seo/related-resources.tsx
+++ b/src/components/seo/related-resources.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import type { PublicResource } from "@/lib/public-resources";
+import { RESOURCE_HUB, relatedResources } from "@/lib/public-resources";
+
+export function RelatedResources({
+  currentPath,
+  items,
+}: {
+  currentPath: string;
+  items?: readonly PublicResource[];
+}) {
+  const related = items ?? relatedResources(currentPath);
+
+  return (
+    <section className="border-t pt-8" aria-labelledby="related-heading">
+      <h2 id="related-heading" className="mb-3 text-lg font-semibold">
+        Recursos relacionados
+      </h2>
+      <ul className="space-y-2 text-sm">
+        {related.map((page) => (
+          <li key={page.path}>
+            <Link href={page.path} className="text-primary underline-offset-4 hover:underline">
+              {page.title}
+            </Link>
+            <span className="text-muted-foreground"> — {page.blurb}</span>
+          </li>
+        ))}
+        <li>
+          <Link
+            href={RESOURCE_HUB.path}
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            Ver todos los recursos
+          </Link>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/ai-referrers.ts
+++ b/src/lib/ai-referrers.ts
@@ -1,0 +1,22 @@
+export const AI_REFERRER_HOSTS = [
+  "chatgpt.com",
+  "chat.openai.com",
+  "claude.ai",
+  "perplexity.ai",
+  "copilot.microsoft.com",
+] as const;
+
+export function matchAiReferrerHost(hostname: string): string | null {
+  const host = hostname.replace(/^www\./, "").toLowerCase();
+  return AI_REFERRER_HOSTS.find((item) => host === item || host.endsWith(`.${item}`)) ?? null;
+}
+
+export function utmParamsFromSearch(search: string): Record<string, string> {
+  const params = new URLSearchParams(search.startsWith("?") ? search : `?${search}`);
+  const utm: Record<string, string> = {};
+  for (const key of ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]) {
+    const value = params.get(key)?.trim();
+    if (value) utm[key] = value.slice(0, 100);
+  }
+  return utm;
+}

--- a/src/lib/public-resources.ts
+++ b/src/lib/public-resources.ts
@@ -1,0 +1,172 @@
+export type PublicResource = {
+  path: string;
+  title: string;
+  description: string;
+  blurb: string;
+  keywords?: readonly string[];
+};
+
+/** Hub de artículos informativos. */
+export const RESOURCE_HUB = {
+  path: "/recursos",
+  title: "Recursos sobre comunicaciones digitales verificables",
+  description:
+    "Guías de Notificas sobre notificaciones por WhatsApp, evidencia, intimaciones, envíos masivos, email verificable y diferencias con la carta documento.",
+  blurb: "Artículos informativos para empresas, profesionales y verificación pública.",
+} as const satisfies PublicResource;
+
+/** Guías públicas ya existentes. */
+export const SEO_GUIDE_PAGES = [
+  {
+    path: "/notificacion-fehaciente-digital",
+    title: "Qué es una notificación fehaciente digital",
+    description:
+      "Qué deja constancia Notificas, qué no prueba un correo aceptado y cómo se usa un certificado de lectura en Argentina.",
+    blurb: "Qué se registra, qué no, y cómo usarlo.",
+  },
+  {
+    path: "/carta-documento-digital",
+    title: "Carta documento digital: qué cubre Notificas y qué no",
+    description:
+      "Notificas no reemplaza una carta documento si la ley pide esa forma. Compará costos, plazos y valor de la constancia técnica.",
+    blurb: "No reemplaza la carta documento. Sí deja rastro comprobable.",
+  },
+  {
+    path: "/notificaciones-whatsapp-empresas",
+    title: "Notificaciones por WhatsApp para empresas",
+    description:
+      "Campañas de volumen por WhatsApp Business: plantillas de Meta, qué se certifica y cómo se cotizan los envíos masivos.",
+    blurb: "Plantillas de Meta, trazabilidad y campañas de volumen.",
+  },
+  {
+    path: "/como-verificar-certificado",
+    title: "Cómo verificar un certificado de Notificas",
+    description:
+      "Subí el PDF o ingresá el ID en notificas.com.ar/verify. Comparamos la huella del archivo con el registro en Polygon.",
+    blurb: "Validá un PDF o un ID contra Polygon.",
+  },
+] as const satisfies readonly PublicResource[];
+
+/** Landings GEO/AEO nuevas: una pregunta real por URL. */
+export const GEO_LANDING_PAGES = [
+  {
+    path: "/notificacion-whatsapp",
+    title: "Notificaciones por WhatsApp con evidencia verificable",
+    description:
+      "Notificaciones por WhatsApp con evidencia verificable: registro de envío, destinatario y eventos. El valor jurídico depende del caso y la forma exigida.",
+    blurb: "Cómo notificar por WhatsApp y qué evidencia queda del envío.",
+    keywords: [
+      "notificación WhatsApp",
+      "notificar por WhatsApp",
+      "WhatsApp comunicación formal",
+      "acreditar envío WhatsApp",
+    ],
+  },
+  {
+    path: "/whatsapp-como-prueba",
+    title: "WhatsApp como prueba: qué evidencia conviene conservar",
+    description:
+      "Qué evidencia de WhatsApp conviene conservar: contenido, destinatario, fecha, entrega, lectura e integridad. El valor jurídico depende del caso.",
+    blurb: "Qué conservar si un WhatsApp puede usarse como elemento de prueba.",
+    keywords: [
+      "WhatsApp como prueba",
+      "evidencia WhatsApp",
+      "prueba de mensajes WhatsApp",
+      "trazabilidad WhatsApp",
+    ],
+  },
+  {
+    path: "/intimacion-deuda-whatsapp",
+    title: "Intimaciones de deuda por WhatsApp: evidencia y trazabilidad",
+    description:
+      "Intimaciones de deuda por WhatsApp: cómo dejar rastro técnico del envío y la entrega, y por qué eso no equivale automáticamente a un requisito legal.",
+    blurb: "Cobranza empresarial: comunicar, acreditar el envío y cumplir formas.",
+    keywords: [
+      "intimación de deuda WhatsApp",
+      "intimar deuda por WhatsApp",
+      "cobranza WhatsApp",
+      "mora WhatsApp empresas",
+    ],
+  },
+  {
+    path: "/notificaciones-masivas-empresas",
+    title: "Notificaciones digitales masivas para empresas",
+    description:
+      "Notificaciones digitales masivas para empresas: WhatsApp y email a escala, carga CSV, trazabilidad por destinatario y cotización según el caso.",
+    blurb: "Envíos de volumen para fintech, bancos, seguros, ecommerce y servicios.",
+    keywords: [
+      "notificaciones masivas empresas",
+      "notificaciones digitales masivas",
+      "campañas WhatsApp empresas",
+      "notificaciones masivas CSV",
+    ],
+  },
+  {
+    path: "/email-certificado",
+    title: "Email verificable: cómo conservar evidencia de una comunicación",
+    description:
+      "Email verificable: cómo conservar evidencia de envío, destinatario, contenido y estado. No equivale por sí solo a una forma legal determinada.",
+    blurb: "Evidencia de correo: envío, estado, trazabilidad y conservación.",
+    keywords: [
+      "email certificado",
+      "email verificable",
+      "correo con constancia de envío",
+      "evidencia de email",
+    ],
+  },
+  {
+    path: "/notificacion-digital-vs-carta-documento",
+    title: "Notificación digital y carta documento: diferencias y casos de uso",
+    description:
+      "Notificación digital y carta documento: compará forma, costos, velocidad, evidencia y límites jurídicos. No son necesariamente equivalentes.",
+    blurb: "Comparación seria: no son el mismo acto ni sustituyen formas exigidas.",
+    keywords: [
+      "notificación digital vs carta documento",
+      "carta documento digital",
+      "diferencia carta documento WhatsApp",
+      "forma de notificación Argentina",
+    ],
+  },
+] as const satisfies readonly PublicResource[];
+
+export const LEGAL_PUBLIC_PAGES = [
+  {
+    path: "/consumidores",
+    title: "Defensa del Consumidor",
+    description:
+      "Información de Defensa del Consumidor de Notificas SRL conforme a la Ley 24.240.",
+    blurb: "Datos del prestador, reclamos y canales de contacto.",
+  },
+  {
+    path: "/terminos",
+    title: "Términos y Condiciones",
+    description: "Términos y condiciones del servicio de Notificas SRL.",
+    blurb: "Condiciones de uso del servicio.",
+  },
+  {
+    path: "/privacidad",
+    title: "Política de Privacidad",
+    description: "Política de privacidad y tratamiento de datos personales de Notificas.",
+    blurb: "Tratamiento de datos personales.",
+  },
+  {
+    path: "/arrepentimiento",
+    title: "Derecho de Arrepentimiento",
+    description: "Ejercé el derecho de arrepentimiento sobre planes contratados en Notificas.",
+    blurb: "Plazo y canal para arrepentirse de una contratación.",
+  },
+] as const satisfies readonly PublicResource[];
+
+export type SeoGuidePath = (typeof SEO_GUIDE_PAGES)[number]["path"];
+export type GeoLandingPath = (typeof GEO_LANDING_PAGES)[number]["path"];
+
+export const ALL_RESOURCE_PAGES = [
+  RESOURCE_HUB,
+  ...SEO_GUIDE_PAGES,
+  ...GEO_LANDING_PAGES,
+] as const;
+
+export function relatedResources(currentPath: string, limit = 6): PublicResource[] {
+  const pool: PublicResource[] = [...SEO_GUIDE_PAGES, ...GEO_LANDING_PAGES];
+  return pool.filter((page) => page.path !== currentPath).slice(0, limit);
+}

--- a/src/lib/robots-policy.ts
+++ b/src/lib/robots-policy.ts
@@ -1,0 +1,51 @@
+/**
+ * Política de crawlers para páginas públicas.
+ *
+ * Separa bots de búsqueda/recuperación (permitidos en rutas públicas) de bots
+ * habitualmente asociados a entrenamiento (no habilitados aquí).
+ */
+
+/** Prefijos que no deben rastrearse ni indexarse. */
+export const PRIVATE_PATH_PREFIXES = [
+  "/api/",
+  "/admin/",
+  "/dashboard/",
+  "/empresa/",
+  "/cuenta/",
+  "/reader/",
+  "/pdf-viewer/",
+  "/process-payment/",
+  "/email-preview/",
+  "/test-firestore/",
+  "/test-polygon/",
+  "/test-reader/",
+  "/linkRedirect",
+] as const;
+
+/** Rutas privadas/sensibles que nunca van al sitemap. */
+export const PRIVATE_SITEMAP_PATHS = [
+  "/login",
+  "/dashboard",
+  "/admin",
+  "/empresa",
+  "/cuenta",
+  "/reader",
+  "/pdf-viewer",
+  "/process-payment",
+  "/email-preview",
+  "/api",
+  "/linkRedirect",
+] as const;
+
+/** Bots de búsqueda / recuperación (ChatGPT, Claude). No son bots de entrenamiento. */
+export const SEARCH_RETRIEVAL_USER_AGENTS = [
+  "OAI-SearchBot",
+  "Claude-SearchBot",
+  "Claude-User",
+] as const;
+
+/**
+ * Bots asociados potencialmente a entrenamiento.
+ * Quedan bloqueados de forma explícita: no se asume consentimiento de training.
+ */
+export const TRAINING_USER_AGENTS = ["GPTBot", "ClaudeBot"] as const;

--- a/src/lib/seo-public.test.ts
+++ b/src/lib/seo-public.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import robots from "../app/robots";
+import sitemap from "../app/sitemap";
+import { GET as llmsTxtGet } from "../app/llms.txt/route";
+import { matchAiReferrerHost, utmParamsFromSearch } from "./ai-referrers";
+import {
+  GEO_LANDING_PAGES,
+  LEGAL_PUBLIC_PAGES,
+  RESOURCE_HUB,
+  SEO_GUIDE_PAGES,
+} from "./public-resources";
+import {
+  PRIVATE_PATH_PREFIXES,
+  PRIVATE_SITEMAP_PATHS,
+  SEARCH_RETRIEVAL_USER_AGENTS,
+  TRAINING_USER_AGENTS,
+} from "./robots-policy";
+import { createPageMetadata, NO_INDEX_METADATA, SITE_URL } from "./seo";
+import {
+  articleJsonLd,
+  breadcrumbJsonLd,
+  faqPageJsonLd,
+  organizationJsonLd,
+  softwareApplicationJsonLd,
+  websiteJsonLd,
+} from "./structured-data";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.join(here, "../app");
+
+const NEW_PUBLIC_PATHS = GEO_LANDING_PAGES.map((page) => page.path);
+const INDEXABLE_PATHS = [
+  "/",
+  "/verify",
+  "/signup",
+  RESOURCE_HUB.path,
+  ...NEW_PUBLIC_PATHS,
+  ...SEO_GUIDE_PAGES.map((page) => page.path),
+  ...LEGAL_PUBLIC_PAGES.map((page) => page.path),
+];
+
+test("robots.txt incluye Allow para crawlers de búsqueda de ChatGPT y Claude", () => {
+  const policy = robots();
+  const rules = Array.isArray(policy.rules) ? policy.rules : [policy.rules];
+  for (const agent of SEARCH_RETRIEVAL_USER_AGENTS) {
+    const rule = rules.find((item) => item.userAgent === agent);
+    assert.ok(rule, `falta regla para ${agent}`);
+    assert.equal(rule?.allow, "/");
+    const disallow = rule?.disallow;
+    const list = Array.isArray(disallow) ? disallow : [disallow];
+    for (const prefix of PRIVATE_PATH_PREFIXES) {
+      assert.ok(list.includes(prefix), `${agent} debe seguir bloqueando ${prefix}`);
+    }
+  }
+});
+
+test("robots.txt no habilita entrenamiento: GPTBot y ClaudeBot quedan en Disallow", () => {
+  const policy = robots();
+  const rules = Array.isArray(policy.rules) ? policy.rules : [policy.rules];
+  for (const agent of TRAINING_USER_AGENTS) {
+    const rule = rules.find((item) => item.userAgent === agent);
+    assert.ok(rule, `falta regla para ${agent}`);
+    assert.equal(rule?.disallow, "/");
+  }
+});
+
+test("robots.txt conserva bloqueo de rutas privadas para *", () => {
+  const policy = robots();
+  const rules = Array.isArray(policy.rules) ? policy.rules : [policy.rules];
+  const star = rules.find((item) => item.userAgent === "*");
+  assert.ok(star);
+  const disallow = star?.disallow;
+  const list = Array.isArray(disallow) ? disallow : [disallow];
+  for (const prefix of PRIVATE_PATH_PREFIXES) {
+    assert.ok(list.includes(prefix));
+  }
+  assert.equal(policy.sitemap, `${SITE_URL}/sitemap.xml`);
+});
+
+test("sitemap incluye las nuevas URLs públicas y omite rutas privadas", () => {
+  const entries = sitemap();
+  const urls = entries.map((entry) => entry.url);
+  for (const publicPath of INDEXABLE_PATHS) {
+    const expected = publicPath === "/" ? SITE_URL : `${SITE_URL}${publicPath}`;
+    assert.ok(urls.includes(expected), `sitemap sin ${expected}`);
+  }
+  for (const privatePath of PRIVATE_SITEMAP_PATHS) {
+    assert.equal(
+      urls.some((url) => url === `${SITE_URL}${privatePath}` || url.includes(`${privatePath}/`)),
+      false,
+      `sitemap no debe incluir ${privatePath}`
+    );
+  }
+});
+
+test("metadata pública tiene canonical, title, description y no usa noindex", () => {
+  for (const page of GEO_LANDING_PAGES) {
+    const meta = createPageMetadata({
+      title: page.title,
+      description: page.description,
+      path: page.path,
+      ogType: "article",
+    });
+    assert.equal(meta.alternates?.canonical, `${SITE_URL}${page.path}`);
+    assert.equal(meta.title, page.title);
+    assert.ok(typeof meta.description === "string" && meta.description.length >= 120);
+    assert.ok(typeof meta.description === "string" && meta.description.length <= 180);
+    assert.equal(meta.openGraph?.url, `${SITE_URL}${page.path}`);
+    assert.equal(meta.openGraph?.siteName, "Notificas");
+    assert.equal(meta.openGraph?.locale, "es_AR");
+    assert.equal((meta.openGraph as { type?: string } | undefined)?.type, "article");
+    const robotsMeta = meta.robots;
+    assert.ok(robotsMeta && typeof robotsMeta === "object" && !Array.isArray(robotsMeta));
+    assert.equal((robotsMeta as { index?: boolean }).index, true);
+    assert.equal((robotsMeta as { follow?: boolean }).follow, true);
+  }
+});
+
+test("rutas privadas conservan noindex", () => {
+  const login = createPageMetadata({
+    title: "Iniciar sesión",
+    description: "Acceso a la cuenta.",
+    path: "/login",
+    noIndex: true,
+  });
+  const robotsMeta = login.robots;
+  assert.ok(robotsMeta && typeof robotsMeta === "object");
+  assert.equal((robotsMeta as { index?: boolean }).index, false);
+  assert.equal((NO_INDEX_METADATA.robots as { index?: boolean }).index, false);
+});
+
+test("JSON-LD de entidad y artículos es JSON válido", () => {
+  const payloads = [
+    organizationJsonLd(),
+    websiteJsonLd(),
+    softwareApplicationJsonLd(),
+    articleJsonLd({
+      title: "Prueba",
+      description: "Desc",
+      path: "/notificacion-whatsapp",
+    }),
+    breadcrumbJsonLd([
+      { name: "Inicio", path: "/" },
+      { name: "Recursos", path: "/recursos" },
+    ]),
+    faqPageJsonLd([{ question: "¿Se puede intimar una deuda por WhatsApp?", answer: "Depende." }]),
+  ];
+  for (const payload of payloads) {
+    const parsed = JSON.parse(JSON.stringify(payload));
+    assert.equal(typeof parsed["@type"], "string");
+  }
+  assert.equal(organizationJsonLd().name, "Notificas");
+  assert.equal(softwareApplicationJsonLd().operatingSystem, "Web");
+  assert.equal(softwareApplicationJsonLd().applicationCategory, "BusinessApplication");
+  assert.equal(websiteJsonLd().url, SITE_URL);
+});
+
+test("existen las páginas públicas nuevas y no marcan noindex en el fuente", () => {
+  for (const page of GEO_LANDING_PAGES) {
+    const file = path.join(appDir, page.path.slice(1), "page.tsx");
+    assert.equal(fs.existsSync(file), true, `falta ${file}`);
+    const src = fs.readFileSync(file, "utf8");
+    assert.match(src, /createPageMetadata/);
+    assert.doesNotMatch(src, /noIndex:\s*true/);
+    assert.match(src, /PublicArticle/);
+    assert.match(src, /lead=/);
+  }
+  assert.equal(fs.existsSync(path.join(appDir, "recursos/page.tsx")), true);
+  assert.equal(fs.existsSync(path.join(appDir, "llms.txt/route.ts")), true);
+  assert.equal(fs.existsSync(path.join(appDir, "robots.ts")), true);
+  assert.equal(fs.existsSync(path.join(appDir, "sitemap.ts")), true);
+});
+
+test("llms.txt responde texto plano con URLs públicas y sin secretos", async () => {
+  const res = llmsTxtGet();
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") || "", /text\/plain/);
+  const body = await res.text();
+  assert.match(body, /Notificas/);
+  assert.match(body, /notificacion-whatsapp/);
+  assert.doesNotMatch(body, /FIREBASE_PRIVATE_KEY/);
+  assert.doesNotMatch(body, /WHATSAPP_ACCESS_TOKEN/);
+  assert.doesNotMatch(body, /CAMPAIGN_WORKER_SECRET/);
+});
+
+test("referers de IA y UTM se reconocen sin inventar fuentes", () => {
+  assert.equal(matchAiReferrerHost("www.chatgpt.com"), "chatgpt.com");
+  assert.equal(matchAiReferrerHost("claude.ai"), "claude.ai");
+  assert.equal(matchAiReferrerHost("www.perplexity.ai"), "perplexity.ai");
+  assert.equal(matchAiReferrerHost("copilot.microsoft.com"), "copilot.microsoft.com");
+  assert.equal(matchAiReferrerHost("evil.example"), null);
+  const utm = utmParamsFromSearch("?utm_source=chatgpt.com&utm_medium=referral&foo=1");
+  assert.equal(utm.utm_source, "chatgpt.com");
+  assert.equal(utm.utm_medium, "referral");
+  assert.equal(utm.foo, undefined);
+});

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,5 +1,12 @@
 import type { Metadata } from "next";
 import { FAQ_CLAIMS } from "@/lib/honest-claims";
+import {
+  GEO_LANDING_PAGES,
+  LEGAL_PUBLIC_PAGES,
+  RESOURCE_HUB,
+  SEO_GUIDE_PAGES,
+  type SeoGuidePath,
+} from "@/lib/public-resources";
 
 /** Dominio canónico de producción (App Hosting). */
 export const SITE_URL = (
@@ -8,38 +15,38 @@ export const SITE_URL = (
 
 export const SITE_NAME = "Notificas";
 export const SITE_LEGAL_NAME = "Notificas SRL";
+
+/** Frase base de posicionamiento (variar la redacción en cada página). */
+export const SITE_POSITIONING =
+  "Notificas es una plataforma de comunicaciones digitales verificables por WhatsApp y email que permite a empresas y profesionales generar y preservar evidencia técnica sobre las distintas etapas de una comunicación.";
+
 export const SITE_TAGLINE =
-  "Notificaciones fehacientes digitales con certificación en blockchain";
+  "Comunicaciones digitales verificables por WhatsApp y email";
 
 export const DEFAULT_TITLE =
-  "Notificas | Notificaciones fehacientes digitales certificadas en blockchain";
+  "Notificas | Comunicaciones digitales verificables por WhatsApp y email";
 
 export const DEFAULT_DESCRIPTION =
-  "Enviá un mensaje y dejá constancia de qué salió, a quién y cuándo. El certificado de lectura se emite una sola vez. Campañas de volumen por WhatsApp y correo, previa cotización.";
+  "Plataforma argentina para comunicaciones digitales verificables por WhatsApp y email, con evidencia técnica, trazabilidad de eventos y verificación pública de constancias.";
 
 export const SITE_KEYWORDS = [
+  "comunicaciones digitales verificables",
+  "notificación WhatsApp",
+  "notificar por WhatsApp",
+  "WhatsApp como prueba",
+  "intimación de deuda WhatsApp",
+  "notificaciones masivas empresas",
+  "email verificable",
+  "notificación digital vs carta documento",
   "notificaciones fehacientes",
   "notificación fehaciente digital",
-  "carta documento digital",
-  "notificaciones certificadas",
-  "notificación certificada online",
-  "comunicación fehaciente",
-  "intimación digital",
-  "certificado blockchain",
-  "Polygon",
-  "prueba de envío",
-  "prueba de lectura",
-  "notificaciones legales Argentina",
+  "constancia de envío digital",
+  "trazabilidad de comunicaciones",
+  "evidencia de WhatsApp",
   "Notificas",
-  "notificaciones de alto volumen",
   "notificaciones WhatsApp empresas",
   "notificaciones por email",
-  "notificaciones digitales certificadas",
-  "notificaciones blockchain",
-  "notificaciones masivas para empresas",
-  "gestión de mora WhatsApp",
   "intimaciones digitales",
-  "comunicaciones empresariales certificadas",
 ] as const;
 
 export const SITE_CONTACT = {
@@ -55,45 +62,25 @@ export const SITE_CONTACT = {
   cuit: "33-71729868-9",
 } as const;
 
+export const CONTENT_EDITOR = SITE_LEGAL_NAME;
+
 /** Fecha real de la última revisión de URLs públicas (no “ahora” en cada build). */
-export const SITEMAP_LASTMOD = new Date("2026-08-25T00:00:00.000Z");
+export const SITEMAP_LASTMOD = new Date("2026-08-27T00:00:00.000Z");
+export const CONTENT_UPDATED_ON = "2026-08-27";
+export const CONTENT_UPDATED_LABEL = "27 de agosto de 2026";
 
-export const SEO_GUIDE_PAGES = [
-  {
-    path: "/notificacion-fehaciente-digital",
-    title: "Qué es una notificación fehaciente digital",
-    description:
-      "Qué deja constancia Notificas, qué no prueba un correo aceptado y cómo se usa un certificado de lectura en Argentina.",
-    blurb: "Qué se registra, qué no, y cómo usarlo.",
-  },
-  {
-    path: "/carta-documento-digital",
-    title: "Carta documento digital: qué cubre Notificas y qué no",
-    description:
-      "Notificas no reemplaza una carta documento si la ley pide esa forma. Compará costos, plazos y valor de la constancia técnica.",
-    blurb: "No reemplaza la carta documento. Sí deja rastro comprobable.",
-  },
-  {
-    path: "/notificaciones-whatsapp-empresas",
-    title: "Notificaciones por WhatsApp para empresas",
-    description:
-      "Campañas de volumen por WhatsApp Business: plantillas de Meta, qué se certifica y cómo se cotizan los envíos masivos.",
-    blurb: "Plantillas de Meta, trazabilidad y campañas de volumen.",
-  },
-  {
-    path: "/como-verificar-certificado",
-    title: "Cómo verificar un certificado de Notificas",
-    description:
-      "Subí el PDF o ingresá el ID en notificas.com.ar/verify. Comparamos la huella del archivo con el registro en Polygon.",
-    blurb: "Validá un PDF o un ID contra Polygon.",
-  },
-] as const;
-
-export type SeoGuidePath = (typeof SEO_GUIDE_PAGES)[number]["path"];
+export { GEO_LANDING_PAGES, LEGAL_PUBLIC_PAGES, RESOURCE_HUB, SEO_GUIDE_PAGES };
+export type { GeoLandingPath, SeoGuidePath } from "@/lib/public-resources";
 
 export function getSeoGuide(path: SeoGuidePath) {
   const page = SEO_GUIDE_PAGES.find((item) => item.path === path);
   if (!page) throw new Error(`SEO guide missing: ${path}`);
+  return page;
+}
+
+export function getGeoLanding(path: (typeof GEO_LANDING_PAGES)[number]["path"]) {
+  const page = GEO_LANDING_PAGES.find((item) => item.path === path);
+  if (!page) throw new Error(`GEO landing missing: ${path}`);
   return page;
 }
 
@@ -112,6 +99,8 @@ type PageMetadataOptions = {
   path: string;
   keywords?: string[];
   noIndex?: boolean;
+  ogType?: "website" | "article";
+  updatedAt?: string;
   /** Si se omite, Next usa `opengraph-image.tsx` / `twitter-image.tsx` del app router. */
   ogImage?: string;
 };
@@ -122,15 +111,52 @@ export function createPageMetadata({
   path,
   keywords,
   noIndex = false,
+  ogType = "website",
+  updatedAt,
   ogImage,
 }: PageMetadataOptions): Metadata {
   const url = absoluteUrl(path);
   const imageUrl = ogImage ? absoluteUrl(ogImage) : undefined;
+  const modified = updatedAt ?? CONTENT_UPDATED_ON;
+  const ogImages = imageUrl
+    ? [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: `${SITE_NAME} — ${SITE_TAGLINE}`,
+        },
+      ]
+    : undefined;
+  const openGraph =
+    ogType === "article"
+      ? {
+          title,
+          description,
+          url,
+          siteName: SITE_NAME,
+          locale: "es_AR" as const,
+          type: "article" as const,
+          publishedTime: `${modified}T00:00:00.000Z`,
+          modifiedTime: `${modified}T00:00:00.000Z`,
+          authors: [CONTENT_EDITOR],
+          ...(ogImages ? { images: ogImages } : {}),
+        }
+      : {
+          title,
+          description,
+          url,
+          siteName: SITE_NAME,
+          locale: "es_AR" as const,
+          type: "website" as const,
+          ...(ogImages ? { images: ogImages } : {}),
+        };
 
   return {
     title,
     description,
     keywords: keywords?.length ? [...keywords] : undefined,
+    authors: [{ name: CONTENT_EDITOR, url: SITE_URL }],
     alternates: {
       canonical: url,
       languages: {
@@ -139,26 +165,7 @@ export function createPageMetadata({
         "x-default": url,
       },
     },
-    openGraph: {
-      title,
-      description,
-      url,
-      siteName: SITE_NAME,
-      locale: "es_AR",
-      type: "website",
-      ...(imageUrl
-        ? {
-            images: [
-              {
-                url: imageUrl,
-                width: 1200,
-                height: 630,
-                alt: `${SITE_NAME} — ${SITE_TAGLINE}`,
-              },
-            ],
-          }
-        : {}),
-    },
+    openGraph,
     twitter: {
       card: "summary_large_image",
       title,
@@ -167,7 +174,17 @@ export function createPageMetadata({
     },
     robots: noIndex
       ? { index: false, follow: false, googleBot: { index: false, follow: false } }
-      : { index: true, follow: true },
+      : {
+          index: true,
+          follow: true,
+          googleBot: {
+            index: true,
+            follow: true,
+            "max-image-preview": "large",
+            "max-snippet": -1,
+            "max-video-preview": -1,
+          },
+        },
   };
 }
 

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -3,8 +3,9 @@ import {
   SITE_CONTACT,
   SITE_LEGAL_NAME,
   SITE_NAME,
-  SITE_TAGLINE,
+  SITE_POSITIONING,
   SITE_URL,
+  CONTENT_UPDATED_ON,
   absoluteUrl,
 } from "@/lib/seo";
 
@@ -17,6 +18,7 @@ export function organizationJsonLd() {
     legalName: SITE_LEGAL_NAME,
     url: SITE_URL,
     logo: absoluteUrl("/notificasLogo.jpg"),
+    image: absoluteUrl("/notificasLogo.jpg"),
     email: SITE_CONTACT.email,
     telephone: SITE_CONTACT.phone,
     taxID: SITE_CONTACT.cuit,
@@ -26,6 +28,10 @@ export function organizationJsonLd() {
       addressLocality: SITE_CONTACT.address.addressLocality,
       addressRegion: SITE_CONTACT.address.addressRegion,
       addressCountry: SITE_CONTACT.address.addressCountry,
+    },
+    areaServed: {
+      "@type": "Country",
+      name: "Argentina",
     },
     contactPoint: [
       {
@@ -47,7 +53,7 @@ export function websiteJsonLd() {
     "@id": `${SITE_URL}/#website`,
     name: SITE_NAME,
     url: SITE_URL,
-    description: SITE_TAGLINE,
+    description: SITE_POSITIONING,
     inLanguage: "es-AR",
     publisher: { "@id": `${SITE_URL}/#organization` },
     potentialAction: {
@@ -61,15 +67,40 @@ export function websiteJsonLd() {
   };
 }
 
+export function softwareApplicationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "@id": `${SITE_URL}/#software`,
+    name: SITE_NAME,
+    url: SITE_URL,
+    description: SITE_POSITIONING,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    inLanguage: "es-AR",
+    provider: { "@id": `${SITE_URL}/#organization` },
+    publisher: { "@id": `${SITE_URL}/#organization` },
+    areaServed: {
+      "@type": "Country",
+      name: "Argentina",
+    },
+    featureList: [
+      "Comunicaciones por WhatsApp Business",
+      "Comunicaciones por email",
+      "Preservación de evidencia técnica y trazabilidad de eventos",
+      "Verificación pública de constancias",
+    ],
+  };
+}
+
 export function serviceJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "Service",
     "@id": `${SITE_URL}/#service`,
-    name: "Notificaciones fehacientes digitales",
-    serviceType: "Notificación fehaciente digital certificada en blockchain",
-    description:
-      "Enviá un mensaje y dejá constancia de qué salió, a quién y cuándo. El certificado de lectura se emite una sola vez. Campañas de volumen por WhatsApp y correo, previa cotización.",
+    name: "Comunicaciones digitales verificables",
+    serviceType: "Comunicación digital verificable por WhatsApp y email",
+    description: SITE_POSITIONING,
     provider: { "@id": `${SITE_URL}/#organization` },
     areaServed: {
       "@type": "Country",
@@ -84,16 +115,18 @@ export function articleJsonLd(opts: {
   title: string;
   description: string;
   path: string;
+  dateModified?: string;
 }) {
   const url = absoluteUrl(opts.path);
+  const day = opts.dateModified ?? CONTENT_UPDATED_ON;
   return {
     "@context": "https://schema.org",
     "@type": "Article",
     headline: opts.title,
     description: opts.description,
     inLanguage: "es-AR",
-    datePublished: "2026-08-25",
-    dateModified: "2026-08-25",
+    datePublished: day,
+    dateModified: day,
     mainEntityOfPage: url,
     url,
     author: { "@id": `${SITE_URL}/#organization` },
@@ -101,12 +134,13 @@ export function articleJsonLd(opts: {
   };
 }
 
-export function faqPageJsonLd() {
+export function faqPageJsonLd(
+  items: ReadonlyArray<{ question: string; answer: string }> = FAQ_SEO_ITEMS
+) {
   return {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    "@id": `${SITE_URL}/#faq`,
-    mainEntity: FAQ_SEO_ITEMS.map((item) => ({
+    mainEntity: items.map((item) => ({
       "@type": "Question",
       name: item.question,
       acceptedAnswer: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué cambia

Mejora la parte **pública** de Notificas para que crawlers de búsqueda (Google, Bing, ChatGPT Search, Claude) puedan rastrear, entender y citar el sitio. No toca autenticación, campañas, pagos, WhatsApp, email, Firebase de negocio ni webhooks.

## Diagnóstico previo

Next.js 15 App Router ya tenía `robots.ts`, `sitemap.ts`, JSON-LD básico (Organization/WebSite/Service), 4 guías y `noindex` en rutas privadas. Faltaban allows explícitos para OAI-SearchBot / Claude-SearchBot / Claude-User, landings GEO/AEO, SoftwareApplication, `llms.txt` y tests de indexabilidad.

## Nuevas URLs públicas

- `/notificacion-whatsapp`
- `/whatsapp-como-prueba`
- `/intimacion-deuda-whatsapp`
- `/notificaciones-masivas-empresas`
- `/email-certificado`
- `/notificacion-digital-vs-carta-documento`
- `/recursos` (hub)
- `/llms.txt` (recurso complementario, no es un estándar garantizado)

## Robots

- `*`, `OAI-SearchBot`, `Claude-SearchBot` y `Claude-User`: Allow `/` con el mismo Disallow de rutas privadas.
- `GPTBot` y `ClaudeBot` (entrenamiento): Disallow `/`. No se asume consentimiento de training.

## Validación local

- `npm test` (82 tests)
- `npm run typecheck`
- lint de los archivos tocados
- `next build` y HTTP 200 de robots, sitemap, llms.txt y las landings nuevas

## Pasos manuales post-deploy

1. Cloudflare: confirmar que Super Bot Fight / WAF no bloquea OAI-SearchBot, Claude-SearchBot ni Claude-User.
2. Google Search Console: solicitar indexación de las URLs nuevas listadas arriba.
3. Firebase Analytics: el evento `ai_referral` (param `ai_source`) identifica referers de chatgpt.com, claude.ai, perplexity.ai y copilot.microsoft.com; los UTM se conservan en sessionStorage.

## Fuera de alcance (a propósito)

Login, dashboard, campañas, créditos, WhatsApp sending, Resend, webhooks, APIs privadas y Firebase data.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd398514-c33e-4090-974f-cdee1912ba61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd398514-c33e-4090-974f-cdee1912ba61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

