### PR TITLE
Kit: widget de Notificas para probar envíos desde gestión-regatas

### DIFF
--- a/docs/examples/gestion-regatas-embed/README.md
+++ b/docs/examples/gestion-regatas-embed/README.md
@@ -1,0 +1,52 @@
+# Widget de Notificas dentro de gestión-regatas
+
+Este agente no puede pushear al repo `abengolea/gestion-regatas` (403). Aplicá el cambio en tu máquina, en `C:\DEV\gestion-regatas`.
+
+## Aplicar el parche
+
+```bat
+cd C:\DEV\gestion-regatas
+git apply C:\DEV\notificas\docs\examples\gestion-regatas-embed\apply-in-gestion-regatas.patch
+```
+
+Si el path de Notificas es otro, apuntá el `.patch` a esta carpeta.
+
+## Probar un envío real
+
+1. En Notificas (`C:\DEV\notificas`) generá una API key: `/admin/api-keys` o  
+   `npx tsx scripts/create-api-key.ts --orgId ORG_ID --name "Regatas prueba" --env test`
+2. En `C:\DEV\gestion-regatas\.env.local`:
+
+```
+NOTIFICAS_API_KEY=ntf_test_xxxxxxxx
+NOTIFICAS_API_BASE=http://localhost:9006/api/v1
+```
+
+Si Notificas ya está en producción con la API v1:
+
+```
+NOTIFICAS_API_BASE=https://notificas.com.ar/api/v1
+```
+
+3. Levantá los dos proyectos:
+
+```
+C:\DEV\notificas     → npm run dev     (puerto 9006)
+C:\DEV\gestion-regatas → npm run dev   (puerto 9003)
+```
+
+4. Entrá a Regatas+ como super admin → **Configuración global** → **Probar Notificas (widget)**  
+   URL: http://localhost:9003/dashboard/admin/notificas
+
+La clave `ntf_live_` / `ntf_test_` **no** va en el HTML. El widget llama a `/api/notificas` en Regatas; el servidor reenvía a Notificas.
+
+Si falta `NOTIFICAS_API_KEY`, la ventana igual aparece en modo demo (no envía).
+
+## Archivos que agrega el parche
+
+- `public/sdk/v1/notificas.js`
+- `src/lib/notificas-embed.ts`
+- `src/app/api/notificas/session/route.ts`
+- `src/app/api/notificas/[...path]/route.ts`
+- `src/app/dashboard/admin/notificas/page.tsx`
+- link en Configuración global + vars en `.env.example`

--- a/docs/examples/gestion-regatas-embed/apply-in-gestion-regatas.patch
+++ b/docs/examples/gestion-regatas-embed/apply-in-gestion-regatas.patch
@@ -1,0 +1,905 @@
+From 0aee986865df8e62b1c712439e1afe7f58bf5392 Mon Sep 17 00:00:00 2001
+From: Cursor Agent <cursoragent@cursor.com>
+Date: Fri, 28 Aug 2026 20:06:26 +0000
+Subject: [PATCH] =?UTF-8?q?feat:=20insertar=20el=20widget=20de=20Notificas?=
+ =?UTF-8?q?=20en=20el=20panel=20para=20probar=20env=C3=ADos.?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Página /dashboard/admin/notificas con el SDK embebible, proxy autenticado
+hacia la API pública y la clave solo en el servidor.
+---
+ .env.example                               |   7 +
+ public/sdk/v1/notificas.js                 | 415 +++++++++++++++++++++
+ src/app/api/notificas/[...path]/route.ts   | 102 +++++
+ src/app/api/notificas/session/route.ts     |  38 ++
+ src/app/dashboard/admin/config/page.tsx    |  16 +-
+ src/app/dashboard/admin/notificas/page.tsx | 174 +++++++++
+ src/components/layout/SidebarNav.tsx       |   1 +
+ src/lib/notificas-embed.ts                 |  48 +++
+ 8 files changed, 798 insertions(+), 3 deletions(-)
+ create mode 100644 public/sdk/v1/notificas.js
+ create mode 100644 src/app/api/notificas/[...path]/route.ts
+ create mode 100644 src/app/api/notificas/session/route.ts
+ create mode 100644 src/app/dashboard/admin/notificas/page.tsx
+ create mode 100644 src/lib/notificas-embed.ts
+
+diff --git a/.env.example b/.env.example
+index 0198e8c..0097dd3 100644
+--- a/.env.example
++++ b/.env.example
+@@ -55,3 +55,10 @@ SANTANDER_PAY_ENABLED=false
+ 
+ # Viajes - Notificaciones email (opcional)
+ # SENDGRID_API_KEY=SG....
++
++# --- Notificas (notificaciones certificadas, widget en /dashboard/admin/notificas) ---
++# Generar en Notificas → /admin/api-keys (nunca pongas ntf_live_ en el frontend).
++# NOTIFICAS_API_KEY=ntf_test_xxxxxxxx
++# Producción: https://notificas.com.ar/api/v1
++# Notificas local (repo C:\DEV\notificas): http://localhost:9006/api/v1
++# NOTIFICAS_API_BASE=https://notificas.com.ar/api/v1
+diff --git a/public/sdk/v1/notificas.js b/public/sdk/v1/notificas.js
+new file mode 100644
+index 0000000..8418926
+--- /dev/null
++++ b/public/sdk/v1/notificas.js
+@@ -0,0 +1,415 @@
++/**
++ * Notificas Web SDK v1 — instrumento para insertar la API en sitios.
++ *
++ * <script src="https://notificas.com.ar/sdk/v1/notificas.js"></script>
++ *
++ * Uso recomendado en webs públicas: proxyUrl (la API Key queda en tu servidor).
++ * No pongas ntf_live_… en HTML público.
++ */
++(function (root, factory) {
++  var api = factory();
++  if (typeof module === "object" && module.exports) {
++    module.exports = api;
++  }
++  if (typeof root === "object" && root) {
++    root.Notificas = api;
++  }
++})(typeof globalThis !== "undefined" ? globalThis : this, function () {
++  "use strict";
++
++  var VERSION = "1.0.0";
++  var DEFAULT_BASE = "https://notificas.com.ar";
++  var STYLE_ID = "notificas-embed-css";
++
++  function isBrowser() {
++    return typeof window !== "undefined" && typeof document !== "undefined";
++  }
++
++  function trimSlash(url) {
++    return String(url || "").replace(/\/+$/, "");
++  }
++
++  function randomIdempotencyKey() {
++    if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
++    return "web_" + Date.now().toString(36) + "_" + Math.random().toString(36).slice(2, 10);
++  }
++
++  function isLiveKey(key) {
++    return String(key || "").trim().indexOf("ntf_live_") === 0;
++  }
++
++  function assertBrowserKeySafe(opts) {
++    var apiKey = opts && opts.apiKey;
++    var proxyUrl = opts && opts.proxyUrl;
++    var allow = opts && opts.allowBrowserKey === true;
++    if (proxyUrl) return;
++    if (!apiKey) {
++      throw new Error("Notificas: definí proxyUrl (recomendado) o apiKey.");
++    }
++    if (isBrowser() && isLiveKey(apiKey) && !allow) {
++      throw new Error(
++        "Notificas: no uses una clave ntf_live_ en el navegador. Configurá proxyUrl hacia tu backend."
++      );
++    }
++  }
++
++  function requestHeaders(opts, extra) {
++    var headers = { "Content-Type": "application/json", Accept: "application/json" };
++    if (opts.apiKey && !opts.proxyUrl) headers.Authorization = "Bearer " + opts.apiKey;
++    if (opts.requestId) headers["X-Request-Id"] = opts.requestId;
++    if (extra) {
++      for (var k in extra) if (Object.prototype.hasOwnProperty.call(extra, k) && extra[k]) headers[k] = extra[k];
++    }
++    return headers;
++  }
++
++  function stripApiV1(path) {
++    var p = String(path || "");
++    if (p.indexOf("/api/v1/") === 0) return p.slice("/api/v1".length);
++    if (p === "/api/v1") return "";
++    return p;
++  }
++
++  function resolveUrl(opts, path) {
++    if (opts.proxyUrl) {
++      var proxy = trimSlash(opts.proxyUrl);
++      if (opts.proxyMapsFullPath) return proxy + path;
++      return proxy + stripApiV1(path);
++    }
++    return trimSlash(opts.baseUrl || DEFAULT_BASE) + path;
++  }
++
++  function parseError(status, body, requestId) {
++    var errBody = body && body.error ? body.error : {};
++    var error = new Error(errBody.message || "HTTP " + status);
++    error.name = "NotificasApiError";
++    error.status = status;
++    error.type = errBody.type || "api_error";
++    error.code = errBody.code || "http_error";
++    error.requestId = errBody.request_id || requestId || null;
++    error.param = errBody.param;
++    return error;
++  }
++
++  function createClient(options) {
++    var opts = options || {};
++    assertBrowserKeySafe(opts);
++    if (!opts.baseUrl) opts.baseUrl = DEFAULT_BASE;
++
++    function request(method, path, body, extraHeaders) {
++      var url = resolveUrl(opts, path);
++      var init = { method: method, headers: requestHeaders(opts, extraHeaders) };
++      if (body !== undefined && body !== null && method !== "GET") init.body = JSON.stringify(body);
++      return fetch(url, init).then(function (res) {
++        return res.json().catch(function () { return {}; }).then(function (json) {
++          var requestId =
++            res.headers && typeof res.headers.get === "function"
++              ? res.headers.get("X-Request-Id")
++              : null;
++          if (!res.ok) throw parseError(res.status, json, requestId);
++          return json;
++        });
++      });
++    }
++
++    return {
++      version: VERSION,
++      sendCertifiedNotification: function (input) {
++        var payload = input || {};
++        var idem = payload.idempotencyKey || randomIdempotencyKey();
++        var body = {
++          channel: payload.channel,
++          recipient: payload.recipient,
++          template: payload.template,
++          variables: payload.variables,
++          subject: payload.subject,
++          body: payload.body,
++          reference: payload.reference,
++          metadata: payload.metadata,
++        };
++        return request("POST", "/api/v1/notifications", body, { "Idempotency-Key": idem });
++      },
++      getNotification: function (id) {
++        return request("GET", "/api/v1/notifications/" + encodeURIComponent(id));
++      },
++      getCertificate: function (id) {
++        return request("GET", "/api/v1/notifications/" + encodeURIComponent(id) + "/certificate");
++      },
++      listNotifications: function (query) {
++        var q = query || {};
++        var params = new URLSearchParams();
++        Object.keys(q).forEach(function (k) {
++          if (q[k] != null && q[k] !== "") params.set(k, String(q[k]));
++        });
++        var qs = params.toString();
++        return request("GET", "/api/v1/notifications" + (qs ? "?" + qs : ""));
++      },
++      me: function () {
++        return request("GET", "/api/v1/me");
++      },
++    };
++  }
++
++  function css() {
++    return [
++      ".ntf-embed{all:initial;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;display:block;max-width:440px;}",
++      ".ntf-embed *{box-sizing:border-box;font-family:inherit;}",
++      ".ntf-card{border:1px solid #d7e0e2;border-radius:12px;background:#fff;padding:20px 20px 16px;box-shadow:0 8px 24px rgba(15,23,42,.06);}",
++      ".ntf-brand{display:flex;align-items:center;gap:8px;margin-bottom:4px;}",
++      ".ntf-mark{width:28px;height:28px;border-radius:8px;background:#0D9488;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;}",
++      ".ntf-title{font-size:16px;font-weight:700;margin:0;}",
++      ".ntf-sub{font-size:12px;color:#64748b;margin:0 0 14px;line-height:1.45;}",
++      ".ntf-row{display:flex;gap:8px;}",
++      ".ntf-field{display:flex;flex-direction:column;gap:4px;margin-bottom:10px;flex:1;}",
++      ".ntf-field label{font-size:12px;font-weight:600;color:#334155;}",
++      ".ntf-field input,.ntf-field select,.ntf-field textarea{width:100%;border:1px solid #cbd5e1;border-radius:8px;padding:8px 10px;font-size:14px;background:#fff;color:#0f172a;}",
++      ".ntf-field textarea{min-height:64px;resize:vertical;}",
++      ".ntf-field input:focus,.ntf-field select:focus,.ntf-field textarea:focus{outline:2px solid #99f6e4;border-color:#0D9488;}",
++      ".ntf-btn{width:100%;border:0;border-radius:8px;background:#0D9488;color:#fff;font-weight:700;font-size:14px;padding:10px 12px;cursor:pointer;}",
++      ".ntf-btn:disabled{opacity:.6;cursor:not-allowed;}",
++      ".ntf-btn:hover:not(:disabled){background:#0f766e;}",
++      ".ntf-msg{margin-top:10px;font-size:13px;line-height:1.4;border-radius:8px;padding:8px 10px;}",
++      ".ntf-ok{background:#ecfdf5;color:#065f46;}",
++      ".ntf-err{background:#fef2f2;color:#991b1b;}",
++      ".ntf-foot{margin-top:10px;font-size:11px;color:#94a3b8;}",
++      ".ntf-foot a{color:#0D9488;text-decoration:none;}",
++    ].join("");
++  }
++
++  function ensureStyle() {
++    if (!isBrowser() || document.getElementById(STYLE_ID)) return;
++    var el = document.createElement("style");
++    el.id = STYLE_ID;
++    el.textContent = css();
++    document.head.appendChild(el);
++  }
++
++  function el(tag, attrs, children) {
++    var node = document.createElement(tag);
++    if (attrs) {
++      Object.keys(attrs).forEach(function (k) {
++        if (k === "className") node.className = attrs[k];
++        else if (k === "text") node.textContent = attrs[k];
++        else if (k.indexOf("on") === 0 && typeof attrs[k] === "function") node.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
++        else if (attrs[k] != null) node.setAttribute(k, String(attrs[k]));
++      });
++    }
++    (children || []).forEach(function (c) {
++      if (c) node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
++    });
++    return node;
++  }
++
++  function field(label, input) {
++    return el("div", { className: "ntf-field" }, [el("label", { text: label }), input]);
++  }
++
++  function parseVariables(raw) {
++    var t = String(raw || "").trim();
++    if (!t) return {};
++    if (t.charAt(0) === "{") {
++      var json = JSON.parse(t);
++      if (!json || typeof json !== "object" || Array.isArray(json)) throw new Error("variables inválidas");
++      return json;
++    }
++    var out = {};
++    t.split(/[\n,]/).forEach(function (line) {
++      var i = line.indexOf("=");
++      if (i < 1) return;
++      out[line.slice(0, i).trim()] = line.slice(i + 1).trim();
++    });
++    return out;
++  }
++
++  function embed(target, options) {
++    if (!isBrowser()) throw new Error("Notificas.embed solo funciona en el navegador.");
++    ensureStyle();
++    var opts = options || {};
++    var mount = typeof target === "string" ? document.querySelector(target) : target;
++    if (!mount) throw new Error("Notificas.embed: no se encontró el contenedor.");
++
++    var client = null;
++    if (!opts.demo) client = createClient(opts);
++
++    mount.innerHTML = "";
++    var root = el("div", { className: "ntf-embed" });
++    var channel = el("select", null, [
++      el("option", { value: "whatsapp", text: "WhatsApp" }),
++      el("option", { value: "email", text: "Email" }),
++    ]);
++    channel.value = opts.channel === "email" ? "email" : "whatsapp";
++    var name = el("input", { type: "text", autocomplete: "name", maxlength: "120" });
++    var phone = el("input", { type: "tel", autocomplete: "tel", placeholder: "+54911…" });
++    var email = el("input", { type: "email", autocomplete: "email", placeholder: "correo@dominio.com" });
++    var documentId = el("input", { type: "text", maxlength: "20", placeholder: "DNI / CUIT" });
++    var template = el("input", { type: "text", maxlength: "128", placeholder: "notificacion_deuda_180_dias" });
++    if (opts.template) template.value = opts.template;
++    var reference = el("input", { type: "text", maxlength: "128", placeholder: "CLIENTE-12345" });
++    var variables = el("textarea", {
++      placeholder: "nombre=Juan Pérez\ndni=20123456\nmonto=125000",
++    });
++    if (opts.variables && typeof opts.variables === "object") {
++      variables.value = Object.keys(opts.variables)
++        .map(function (k) { return k + "=" + opts.variables[k]; })
++        .join("\n");
++    }
++    var subject = el("input", { type: "text", maxlength: "300", placeholder: "Asunto del correo" });
++    var body = el("textarea", { placeholder: "Texto del mensaje (email)" });
++    var status = el("div");
++    var buttonLabel = opts.buttonLabel || "Enviar notificación";
++    var btn = el("button", { className: "ntf-btn", type: "button", text: buttonLabel });
++
++    function setMsg(ok, text) {
++      status.className = "ntf-msg " + (ok ? "ntf-ok" : "ntf-err");
++      status.textContent = text;
++    }
++
++    function syncChannel() {
++      var wa = channel.value === "whatsapp";
++      phone.parentElement.style.display = wa || opts.showAllFields ? "" : "none";
++      email.parentElement.style.display = !wa || opts.showAllFields ? "" : "none";
++      subject.parentElement.style.display = wa ? "none" : "";
++      body.parentElement.style.display = wa ? "none" : "";
++      template.parentElement.style.display = opts.hideTemplate ? "none" : "";
++    }
++    channel.addEventListener("change", syncChannel);
++
++    btn.addEventListener("click", function () {
++      status.textContent = "";
++      status.className = "";
++      var vars;
++      try {
++        vars = parseVariables(variables.value);
++      } catch (e) {
++        setMsg(false, "Revisá las variables (JSON o clave=valor).");
++        return;
++      }
++      var payload = {
++        channel: channel.value,
++        recipient: {
++          name: name.value.trim() || undefined,
++          phone: phone.value.trim() || undefined,
++          email: email.value.trim() || undefined,
++          document: documentId.value.trim() || undefined,
++        },
++        template: template.value.trim() || undefined,
++        variables: vars,
++        reference: reference.value.trim() || undefined,
++        subject: subject.value.trim() || undefined,
++        body: body.value.trim() || undefined,
++        metadata: opts.metadata,
++      };
++      if (opts.demo) {
++        setMsg(true, "Modo demostración: no se envió nada. En producción usá proxyUrl o una clave de test.");
++        if (typeof opts.onSent === "function") opts.onSent({ id: "ntf_demo", status: "queued", test_mode: true, demo: true });
++        return;
++      }
++      btn.disabled = true;
++      btn.textContent = "Enviando…";
++      client
++        .sendCertifiedNotification(payload)
++        .then(function (res) {
++          var id = res && res.id ? res.id : "";
++          var st = res && res.status ? res.status : "queued";
++          setMsg(true, "Enviada. ID " + id + " · estado " + st + ". Queda constancia técnica de qué se envió, a quién y cuándo.");
++          if (typeof opts.onSent === "function") opts.onSent(res);
++        })
++        .catch(function (err) {
++          setMsg(false, (err && err.message) || "No se pudo enviar.");
++          if (typeof opts.onError === "function") opts.onError(err);
++        })
++        .then(function () {
++          btn.disabled = false;
++          btn.textContent = buttonLabel;
++        });
++    });
++
++    root.appendChild(
++      el("div", { className: "ntf-card" }, [
++        el("div", { className: "ntf-brand" }, [
++          el("div", { className: "ntf-mark", text: "N" }),
++          el("p", { className: "ntf-title", text: opts.title || "Notificación certificada" }),
++        ]),
++        el("p", {
++          className: "ntf-sub",
++          text:
++            opts.subtitle ||
++            "Envía un mensaje y deja constancia de qué salió, a quién y cuándo. No reemplaza una carta documento si la norma pide esa forma.",
++        }),
++        field("Canal", channel),
++        field("Nombre", name),
++        field("Teléfono (WhatsApp)", phone),
++        field("Email", email),
++        field("Documento", documentId),
++        field("Plantilla", template),
++        field("Referencia", reference),
++        field("Variables (clave=valor)", variables),
++        field("Asunto", subject),
++        field("Cuerpo", body),
++        btn,
++        status,
++        el("p", { className: "ntf-foot" }, [
++          document.createTextNode("Instrumento "),
++          el("a", { href: "https://notificas.com.ar/docs/api/embed", text: "Notificas API" }),
++        ]),
++      ])
++    );
++    mount.appendChild(root);
++    syncChannel();
++    return {
++      destroy: function () {
++        mount.innerHTML = "";
++      },
++      client: client,
++    };
++  }
++
++  function autoEmbed() {
++    if (!isBrowser()) return;
++    var nodes = document.querySelectorAll("[data-notificas-embed]");
++    for (var i = 0; i < nodes.length; i++) {
++      var node = nodes[i];
++      if (node.getAttribute("data-notificas-ready") === "1") continue;
++      var varsRaw = node.getAttribute("data-variables");
++      var variables;
++      try {
++        variables = varsRaw ? JSON.parse(varsRaw) : undefined;
++      } catch (e) {
++        variables = undefined;
++      }
++      embed(node, {
++        proxyUrl: node.getAttribute("data-proxy-url") || undefined,
++        apiKey: node.getAttribute("data-api-key") || undefined,
++        allowBrowserKey: node.getAttribute("data-allow-browser-key") === "true",
++        baseUrl: node.getAttribute("data-base-url") || undefined,
++        channel: node.getAttribute("data-channel") || undefined,
++        template: node.getAttribute("data-template") || undefined,
++        title: node.getAttribute("data-title") || undefined,
++        demo: node.getAttribute("data-demo") === "true",
++        hideTemplate: node.getAttribute("data-hide-template") === "true",
++        buttonLabel: node.getAttribute("data-button-label") || undefined,
++        variables: variables,
++      });
++      node.setAttribute("data-notificas-ready", "1");
++    }
++  }
++
++  if (isBrowser()) {
++    if (document.readyState === "loading") {
++      document.addEventListener("DOMContentLoaded", autoEmbed);
++    } else {
++      autoEmbed();
++    }
++  }
++
++  return {
++    version: VERSION,
++    create: createClient,
++    embed: embed,
++    autoEmbed: autoEmbed,
++    _assertBrowserKeySafe: assertBrowserKeySafe,
++    _parseVariables: parseVariables,
++    _resolveUrl: resolveUrl,
++    _isLiveKey: isLiveKey,
++  };
++});
+diff --git a/src/app/api/notificas/[...path]/route.ts b/src/app/api/notificas/[...path]/route.ts
+new file mode 100644
+index 0000000..62c5e04
+--- /dev/null
++++ b/src/app/api/notificas/[...path]/route.ts
+@@ -0,0 +1,102 @@
++/**
++ * Proxy hacia la API pública de Notificas.
++ * El navegador nunca ve NOTIFICAS_API_KEY. Requiere cookie de sesión
++ * abierta por /api/notificas/session (super admin).
++ */
++import { NextRequest, NextResponse } from "next/server";
++import {
++  notificasApiBase,
++  notificasApiConfigured,
++  notificasEmbedCookie,
++  verifyNotificasEmbedSession,
++} from "@/lib/notificas-embed";
++
++const ALLOWED_PREFIXES = ["notifications", "me"];
++
++export async function GET(
++  request: NextRequest,
++  context: { params: Promise<{ path: string[] }> }
++) {
++  return proxy(request, context);
++}
++
++export async function POST(
++  request: NextRequest,
++  context: { params: Promise<{ path: string[] }> }
++) {
++  return proxy(request, context);
++}
++
++async function proxy(
++  request: NextRequest,
++  context: { params: Promise<{ path: string[] }> }
++) {
++  const session = await verifyNotificasEmbedSession(
++    request.cookies.get(notificasEmbedCookie.name)?.value
++  );
++  if (!session) {
++    return NextResponse.json(
++      {
++        error: {
++          code: "unauthorized",
++          message: "Sesión de Notificas vencida. Recargá la página.",
++        },
++      },
++      { status: 401 }
++    );
++  }
++
++  if (!notificasApiConfigured()) {
++    return NextResponse.json(
++      {
++        error: {
++          code: "misconfigured",
++          message: "Falta NOTIFICAS_API_KEY en .env.local de gestión-regatas.",
++        },
++      },
++      { status: 500 }
++    );
++  }
++
++  const { path } = await context.params;
++  const segments = path ?? [];
++  const first = segments[0] ?? "";
++  if (!ALLOWED_PREFIXES.includes(first)) {
++    return NextResponse.json(
++      { error: { code: "forbidden_path", message: "Ruta no permitida." } },
++      { status: 403 }
++    );
++  }
++
++  const search = request.nextUrl.search;
++  const target = `${notificasApiBase()}/${segments.map(encodeURIComponent).join("/")}${search}`;
++  const headers = new Headers();
++  headers.set("Authorization", `Bearer ${process.env.NOTIFICAS_API_KEY!.trim()}`);
++  headers.set("Accept", "application/json");
++  const contentType = request.headers.get("content-type");
++  if (contentType) headers.set("Content-Type", contentType);
++  const idempotency = request.headers.get("Idempotency-Key");
++  if (idempotency) headers.set("Idempotency-Key", idempotency);
++
++  const init: RequestInit = { method: request.method, headers };
++  if (request.method !== "GET" && request.method !== "HEAD") {
++    init.body = await request.text();
++  }
++
++  try {
++    const upstream = await fetch(target, init);
++    const body = await upstream.text();
++    return new NextResponse(body, {
++      status: upstream.status,
++      headers: {
++        "Content-Type": upstream.headers.get("content-type") ?? "application/json",
++      },
++    });
++  } catch (e) {
++    const message = e instanceof Error ? e.message : "No se pudo contactar Notificas.";
++    return NextResponse.json(
++      { error: { code: "upstream_unreachable", message } },
++      { status: 502 }
++    );
++  }
++}
+diff --git a/src/app/api/notificas/session/route.ts b/src/app/api/notificas/session/route.ts
+new file mode 100644
+index 0000000..ff4cff5
+--- /dev/null
++++ b/src/app/api/notificas/session/route.ts
+@@ -0,0 +1,38 @@
++/**
++ * Abre una sesión corta (cookie httpOnly) para que el widget de Notificas
++ * pueda hablar con el proxy sin exponer la API key ni el token de Firebase.
++ * Solo super admin.
++ */
++import { NextResponse } from "next/server";
++import { verifySuperAdmin } from "@/lib/auth-server";
++import {
++  notificasApiConfigured,
++  notificasEmbedCookie,
++  signNotificasEmbedSession,
++} from "@/lib/notificas-embed";
++
++export async function GET(request: Request) {
++  const admin = await verifySuperAdmin(request.headers.get("Authorization"));
++  if (!admin) {
++    return NextResponse.json({ error: { message: "No autorizado" } }, { status: 401 });
++  }
++  return NextResponse.json({ ok: true, configured: notificasApiConfigured() });
++}
++
++export async function POST(request: Request) {
++  const admin = await verifySuperAdmin(request.headers.get("Authorization"));
++  if (!admin) {
++    return NextResponse.json({ error: { message: "No autorizado" } }, { status: 401 });
++  }
++
++  const token = await signNotificasEmbedSession(admin.uid);
++  const res = NextResponse.json({ ok: true, configured: notificasApiConfigured() });
++  res.cookies.set(notificasEmbedCookie.name, token, {
++    httpOnly: true,
++    sameSite: "lax",
++    path: "/",
++    maxAge: notificasEmbedCookie.maxAge,
++    secure: process.env.NODE_ENV === "production",
++  });
++  return res;
++}
+diff --git a/src/app/dashboard/admin/config/page.tsx b/src/app/dashboard/admin/config/page.tsx
+index 04e7d90..789ec87 100644
+--- a/src/app/dashboard/admin/config/page.tsx
++++ b/src/app/dashboard/admin/config/page.tsx
+@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
+ import { Label } from "@/components/ui/label";
+ import { Switch } from "@/components/ui/switch";
+ import { Textarea } from "@/components/ui/textarea";
+-import { Loader2, Settings, Headphones, Mail, History, UserX, ChevronRight } from "lucide-react";
++import { Loader2, Settings, Headphones, Mail, History, UserX, ChevronRight, Send } from "lucide-react";
+ import { useFirestore, useUserProfile, useDoc } from "@/firebase";
+ import { doc, setDoc, serverTimestamp } from "firebase/firestore";
+ import type { PlatformConfig } from "@/lib/types";
+@@ -165,8 +165,8 @@ export default function PlatformConfigPage() {
+         <CardHeader>
+           <CardTitle>Herramientas y soporte</CardTitle>
+           <CardDescription>
+-            Desde aquí accedés a tickets, prueba de correo (Trigger Email), registro de auditoría y
+-            borrado de usuarios de prueba. Estas tres últimas ya no aparecen en el menú lateral.
++            Desde aquí accedés a tickets, prueba de correo, widget de Notificas, auditoría y
++            borrado de usuarios de prueba. Estas últimas ya no aparecen en el menú lateral.
+           </CardDescription>
+         </CardHeader>
+         <CardContent className="space-y-2">
+@@ -190,6 +190,16 @@ export default function PlatformConfigPage() {
+             </span>
+             <ChevronRight className="h-4 w-4 text-muted-foreground" />
+           </Link>
++          <Link
++            href="/dashboard/admin/notificas"
++            className="flex items-center justify-between rounded-lg border p-4 transition-colors hover:bg-muted/50"
++          >
++            <span className="flex items-center gap-3">
++              <Send className="h-5 w-5 text-muted-foreground" />
++              <span>Probar Notificas (widget)</span>
++            </span>
++            <ChevronRight className="h-4 w-4 text-muted-foreground" />
++          </Link>
+           <Link
+             href="/dashboard/admin/audit"
+             className="flex items-center justify-between rounded-lg border p-4 transition-colors hover:bg-muted/50"
+diff --git a/src/app/dashboard/admin/notificas/page.tsx b/src/app/dashboard/admin/notificas/page.tsx
+new file mode 100644
+index 0000000..53d18e6
+--- /dev/null
++++ b/src/app/dashboard/admin/notificas/page.tsx
+@@ -0,0 +1,174 @@
++"use client";
++
++import { useEffect, useState } from "react";
++import { useRouter } from "next/navigation";
++import Link from "next/link";
++import {
++  Card,
++  CardContent,
++  CardDescription,
++  CardHeader,
++  CardTitle,
++} from "@/components/ui/card";
++import { Button } from "@/components/ui/button";
++import { ChevronLeft, Loader2, Send } from "lucide-react";
++import { useUserProfile, useFirebase } from "@/firebase";
++import { getAuth } from "firebase/auth";
++
++declare global {
++  interface Window {
++    Notificas?: {
++      embed: (
++        target: string | Element,
++        options?: Record<string, unknown>
++      ) => { destroy: () => void };
++    };
++  }
++}
++
++export default function NotificasEmbedPage() {
++  const router = useRouter();
++  const { app } = useFirebase();
++  const { isSuperAdmin, isReady } = useUserProfile();
++  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
++  const [configured, setConfigured] = useState(false);
++  const [error, setError] = useState<string | null>(null);
++
++  useEffect(() => {
++    if (!isReady) return;
++    if (!isSuperAdmin) {
++      router.replace("/dashboard");
++    }
++  }, [isReady, isSuperAdmin, router]);
++
++  useEffect(() => {
++    if (!isReady || !isSuperAdmin || !app) return;
++    let cancelled = false;
++
++    async function prepare() {
++      try {
++        const auth = getAuth(app);
++        const user = auth.currentUser;
++        if (!user) {
++          setError("No estás logueado.");
++          setStatus("error");
++          return;
++        }
++        const token = await user.getIdToken();
++        const res = await fetch("/api/notificas/session", {
++          method: "POST",
++          headers: { Authorization: `Bearer ${token}` },
++        });
++        const data = (await res.json().catch(() => ({}))) as {
++          configured?: boolean;
++          error?: { message?: string };
++        };
++        if (!res.ok) {
++          setError(data.error?.message || `Error ${res.status}`);
++          setStatus("error");
++          return;
++        }
++        if (cancelled) return;
++        setConfigured(Boolean(data.configured));
++        setStatus("ready");
++      } catch (e) {
++        if (cancelled) return;
++        setError(e instanceof Error ? e.message : "No se pudo abrir la sesión de Notificas.");
++        setStatus("error");
++      }
++    }
++
++    void prepare();
++    return () => {
++      cancelled = true;
++    };
++  }, [isReady, isSuperAdmin, app]);
++
++  useEffect(() => {
++    if (status !== "ready") return;
++    const existing = document.querySelector<HTMLScriptElement>('script[data-notificas-sdk="v1"]');
++    const mount = () => {
++      const host = document.querySelector("#notificas-regatas-embed");
++      if (!host || host.childElementCount > 0 || !window.Notificas) return;
++      window.Notificas.embed("#notificas-regatas-embed", {
++        proxyUrl: configured ? "/api/notificas" : undefined,
++        demo: !configured,
++        channel: "whatsapp",
++        template: "notificacion_deuda_180_dias",
++        title: "Notificas · Regatas+",
++        buttonLabel: configured ? "Enviar notificación certificada" : "Enviar (demo)",
++      });
++    };
++
++    if (existing && window.Notificas) {
++      mount();
++      return;
++    }
++    const script = document.createElement("script");
++    script.src = "/sdk/v1/notificas.js";
++    script.async = true;
++    script.dataset.notificasSdk = "v1";
++    script.onload = mount;
++    document.body.appendChild(script);
++  }, [status, configured]);
++
++  if (!isReady || !isSuperAdmin) return null;
++
++  return (
++    <div className="container max-w-xl py-6">
++      <Button variant="ghost" size="sm" className="mb-4 -ml-2 text-muted-foreground" asChild>
++        <Link href="/dashboard/admin/config">
++          <ChevronLeft className="h-4 w-4 mr-1" />
++          Configuración global
++        </Link>
++      </Button>
++      <Card>
++        <CardHeader>
++          <div className="flex items-center gap-2">
++            <Send className="h-6 w-6 text-primary" />
++            <CardTitle>Probar Notificas</CardTitle>
++          </div>
++          <CardDescription>
++            Esta es la misma ventana que se inserta en sitios de terceros. La API key queda en el
++            servidor de Regatas+; el widget solo habla con <code>/api/notificas</code>.
++          </CardDescription>
++        </CardHeader>
++        <CardContent className="space-y-4">
++          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
++            La constancia es evidencia técnica del envío. No es firma digital, acto notarial ni
++            carta documento.
++          </div>
++
++          {status === "loading" ? (
++            <p className="flex items-center gap-2 text-sm text-muted-foreground">
++              <Loader2 className="h-4 w-4 animate-spin" />
++              Preparando el widget…
++            </p>
++          ) : null}
++
++          {status === "error" ? (
++            <p className="text-sm text-destructive">{error}</p>
++          ) : null}
++
++          {status === "ready" && !configured ? (
++            <p className="text-sm text-muted-foreground">
++              Falta <code>NOTIFICAS_API_KEY</code> en <code>.env.local</code>. El widget está en modo
++              demo (no envía). Generá una clave en Notificas (<code>/admin/api-keys</code>) y
++              reiniciá <code>npm run dev</code>. Para pegarle a un Notificas local usá{" "}
++              <code>NOTIFICAS_API_BASE=http://localhost:9006/api/v1</code>.
++            </p>
++          ) : null}
++
++          {status === "ready" && configured ? (
++            <p className="text-sm text-muted-foreground">
++              Listo para enviar de verdad. Completá destinatario y plantilla, y usá un teléfono o
++              email que puedas verificar.
++            </p>
++          ) : null}
++
++          <div id="notificas-regatas-embed" />
++        </CardContent>
++      </Card>
++    </div>
++  );
++}
+diff --git a/src/components/layout/SidebarNav.tsx b/src/components/layout/SidebarNav.tsx
+index 21a2de2..1e40c6b 100644
+--- a/src/components/layout/SidebarNav.tsx
++++ b/src/components/layout/SidebarNav.tsx
+@@ -80,6 +80,7 @@ const schoolUserMenuItemsProfesor: NavItem[] = [
+ const SUPER_ADMIN_CONFIG_HUB_PATHS = new Set([
+   "/dashboard/admin/config",
+   "/dashboard/admin/test-email",
++  "/dashboard/admin/notificas",
+   "/dashboard/admin/audit",
+   "/dashboard/admin/delete-test-users",
+ ]);
+diff --git a/src/lib/notificas-embed.ts b/src/lib/notificas-embed.ts
+new file mode 100644
+index 0000000..bf6dd55
+--- /dev/null
++++ b/src/lib/notificas-embed.ts
+@@ -0,0 +1,48 @@
++import { SignJWT, jwtVerify } from "jose";
++
++const COOKIE_NAME = "notificas_embed";
++const COOKIE_MAX_AGE = 30 * 60;
++
++function embedSecret() {
++  const raw =
++    process.env.NOTIFICAS_EMBED_SECRET?.trim() ||
++    process.env.QR_JWT_SECRET?.trim() ||
++    "dev-notificas-embed";
++  return new TextEncoder().encode(raw);
++}
++
++export function notificasApiConfigured(): boolean {
++  return Boolean(process.env.NOTIFICAS_API_KEY?.trim());
++}
++
++export function notificasApiBase(): string {
++  return (process.env.NOTIFICAS_API_BASE?.trim() || "https://notificas.com.ar/api/v1").replace(
++    /\/$/,
++    ""
++  );
++}
++
++export async function signNotificasEmbedSession(uid: string): Promise<string> {
++  return new SignJWT({ uid, scope: "notificas_embed" })
++    .setProtectedHeader({ alg: "HS256" })
++    .setExpirationTime(`${COOKIE_MAX_AGE}s`)
++    .sign(embedSecret());
++}
++
++export async function verifyNotificasEmbedSession(
++  token: string | undefined
++): Promise<{ uid: string } | null> {
++  if (!token) return null;
++  try {
++    const { payload } = await jwtVerify(token, embedSecret());
++    if (payload.scope !== "notificas_embed" || typeof payload.uid !== "string") return null;
++    return { uid: payload.uid };
++  } catch {
++    return null;
++  }
++}
++
++export const notificasEmbedCookie = {
++  name: COOKIE_NAME,
++  maxAge: COOKIE_MAX_AGE,
++} as const;
+-- 
+2.43.0
+

--- a/docs/examples/gestion-regatas-embed/public/sdk/v1/notificas.js
+++ b/docs/examples/gestion-regatas-embed/public/sdk/v1/notificas.js
@@ -1,0 +1,415 @@
+/**
+ * Notificas Web SDK v1 — instrumento para insertar la API en sitios.
+ *
+ * <script src="https://notificas.com.ar/sdk/v1/notificas.js"></script>
+ *
+ * Uso recomendado en webs públicas: proxyUrl (la API Key queda en tu servidor).
+ * No pongas ntf_live_… en HTML público.
+ */
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  if (typeof root === "object" && root) {
+    root.Notificas = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  var VERSION = "1.0.0";
+  var DEFAULT_BASE = "https://notificas.com.ar";
+  var STYLE_ID = "notificas-embed-css";
+
+  function isBrowser() {
+    return typeof window !== "undefined" && typeof document !== "undefined";
+  }
+
+  function trimSlash(url) {
+    return String(url || "").replace(/\/+$/, "");
+  }
+
+  function randomIdempotencyKey() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+    return "web_" + Date.now().toString(36) + "_" + Math.random().toString(36).slice(2, 10);
+  }
+
+  function isLiveKey(key) {
+    return String(key || "").trim().indexOf("ntf_live_") === 0;
+  }
+
+  function assertBrowserKeySafe(opts) {
+    var apiKey = opts && opts.apiKey;
+    var proxyUrl = opts && opts.proxyUrl;
+    var allow = opts && opts.allowBrowserKey === true;
+    if (proxyUrl) return;
+    if (!apiKey) {
+      throw new Error("Notificas: definí proxyUrl (recomendado) o apiKey.");
+    }
+    if (isBrowser() && isLiveKey(apiKey) && !allow) {
+      throw new Error(
+        "Notificas: no uses una clave ntf_live_ en el navegador. Configurá proxyUrl hacia tu backend."
+      );
+    }
+  }
+
+  function requestHeaders(opts, extra) {
+    var headers = { "Content-Type": "application/json", Accept: "application/json" };
+    if (opts.apiKey && !opts.proxyUrl) headers.Authorization = "Bearer " + opts.apiKey;
+    if (opts.requestId) headers["X-Request-Id"] = opts.requestId;
+    if (extra) {
+      for (var k in extra) if (Object.prototype.hasOwnProperty.call(extra, k) && extra[k]) headers[k] = extra[k];
+    }
+    return headers;
+  }
+
+  function stripApiV1(path) {
+    var p = String(path || "");
+    if (p.indexOf("/api/v1/") === 0) return p.slice("/api/v1".length);
+    if (p === "/api/v1") return "";
+    return p;
+  }
+
+  function resolveUrl(opts, path) {
+    if (opts.proxyUrl) {
+      var proxy = trimSlash(opts.proxyUrl);
+      if (opts.proxyMapsFullPath) return proxy + path;
+      return proxy + stripApiV1(path);
+    }
+    return trimSlash(opts.baseUrl || DEFAULT_BASE) + path;
+  }
+
+  function parseError(status, body, requestId) {
+    var errBody = body && body.error ? body.error : {};
+    var error = new Error(errBody.message || "HTTP " + status);
+    error.name = "NotificasApiError";
+    error.status = status;
+    error.type = errBody.type || "api_error";
+    error.code = errBody.code || "http_error";
+    error.requestId = errBody.request_id || requestId || null;
+    error.param = errBody.param;
+    return error;
+  }
+
+  function createClient(options) {
+    var opts = options || {};
+    assertBrowserKeySafe(opts);
+    if (!opts.baseUrl) opts.baseUrl = DEFAULT_BASE;
+
+    function request(method, path, body, extraHeaders) {
+      var url = resolveUrl(opts, path);
+      var init = { method: method, headers: requestHeaders(opts, extraHeaders) };
+      if (body !== undefined && body !== null && method !== "GET") init.body = JSON.stringify(body);
+      return fetch(url, init).then(function (res) {
+        return res.json().catch(function () { return {}; }).then(function (json) {
+          var requestId =
+            res.headers && typeof res.headers.get === "function"
+              ? res.headers.get("X-Request-Id")
+              : null;
+          if (!res.ok) throw parseError(res.status, json, requestId);
+          return json;
+        });
+      });
+    }
+
+    return {
+      version: VERSION,
+      sendCertifiedNotification: function (input) {
+        var payload = input || {};
+        var idem = payload.idempotencyKey || randomIdempotencyKey();
+        var body = {
+          channel: payload.channel,
+          recipient: payload.recipient,
+          template: payload.template,
+          variables: payload.variables,
+          subject: payload.subject,
+          body: payload.body,
+          reference: payload.reference,
+          metadata: payload.metadata,
+        };
+        return request("POST", "/api/v1/notifications", body, { "Idempotency-Key": idem });
+      },
+      getNotification: function (id) {
+        return request("GET", "/api/v1/notifications/" + encodeURIComponent(id));
+      },
+      getCertificate: function (id) {
+        return request("GET", "/api/v1/notifications/" + encodeURIComponent(id) + "/certificate");
+      },
+      listNotifications: function (query) {
+        var q = query || {};
+        var params = new URLSearchParams();
+        Object.keys(q).forEach(function (k) {
+          if (q[k] != null && q[k] !== "") params.set(k, String(q[k]));
+        });
+        var qs = params.toString();
+        return request("GET", "/api/v1/notifications" + (qs ? "?" + qs : ""));
+      },
+      me: function () {
+        return request("GET", "/api/v1/me");
+      },
+    };
+  }
+
+  function css() {
+    return [
+      ".ntf-embed{all:initial;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;display:block;max-width:440px;}",
+      ".ntf-embed *{box-sizing:border-box;font-family:inherit;}",
+      ".ntf-card{border:1px solid #d7e0e2;border-radius:12px;background:#fff;padding:20px 20px 16px;box-shadow:0 8px 24px rgba(15,23,42,.06);}",
+      ".ntf-brand{display:flex;align-items:center;gap:8px;margin-bottom:4px;}",
+      ".ntf-mark{width:28px;height:28px;border-radius:8px;background:#0D9488;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;}",
+      ".ntf-title{font-size:16px;font-weight:700;margin:0;}",
+      ".ntf-sub{font-size:12px;color:#64748b;margin:0 0 14px;line-height:1.45;}",
+      ".ntf-row{display:flex;gap:8px;}",
+      ".ntf-field{display:flex;flex-direction:column;gap:4px;margin-bottom:10px;flex:1;}",
+      ".ntf-field label{font-size:12px;font-weight:600;color:#334155;}",
+      ".ntf-field input,.ntf-field select,.ntf-field textarea{width:100%;border:1px solid #cbd5e1;border-radius:8px;padding:8px 10px;font-size:14px;background:#fff;color:#0f172a;}",
+      ".ntf-field textarea{min-height:64px;resize:vertical;}",
+      ".ntf-field input:focus,.ntf-field select:focus,.ntf-field textarea:focus{outline:2px solid #99f6e4;border-color:#0D9488;}",
+      ".ntf-btn{width:100%;border:0;border-radius:8px;background:#0D9488;color:#fff;font-weight:700;font-size:14px;padding:10px 12px;cursor:pointer;}",
+      ".ntf-btn:disabled{opacity:.6;cursor:not-allowed;}",
+      ".ntf-btn:hover:not(:disabled){background:#0f766e;}",
+      ".ntf-msg{margin-top:10px;font-size:13px;line-height:1.4;border-radius:8px;padding:8px 10px;}",
+      ".ntf-ok{background:#ecfdf5;color:#065f46;}",
+      ".ntf-err{background:#fef2f2;color:#991b1b;}",
+      ".ntf-foot{margin-top:10px;font-size:11px;color:#94a3b8;}",
+      ".ntf-foot a{color:#0D9488;text-decoration:none;}",
+    ].join("");
+  }
+
+  function ensureStyle() {
+    if (!isBrowser() || document.getElementById(STYLE_ID)) return;
+    var el = document.createElement("style");
+    el.id = STYLE_ID;
+    el.textContent = css();
+    document.head.appendChild(el);
+  }
+
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        if (k === "className") node.className = attrs[k];
+        else if (k === "text") node.textContent = attrs[k];
+        else if (k.indexOf("on") === 0 && typeof attrs[k] === "function") node.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
+        else if (attrs[k] != null) node.setAttribute(k, String(attrs[k]));
+      });
+    }
+    (children || []).forEach(function (c) {
+      if (c) node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    });
+    return node;
+  }
+
+  function field(label, input) {
+    return el("div", { className: "ntf-field" }, [el("label", { text: label }), input]);
+  }
+
+  function parseVariables(raw) {
+    var t = String(raw || "").trim();
+    if (!t) return {};
+    if (t.charAt(0) === "{") {
+      var json = JSON.parse(t);
+      if (!json || typeof json !== "object" || Array.isArray(json)) throw new Error("variables inválidas");
+      return json;
+    }
+    var out = {};
+    t.split(/[\n,]/).forEach(function (line) {
+      var i = line.indexOf("=");
+      if (i < 1) return;
+      out[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+    });
+    return out;
+  }
+
+  function embed(target, options) {
+    if (!isBrowser()) throw new Error("Notificas.embed solo funciona en el navegador.");
+    ensureStyle();
+    var opts = options || {};
+    var mount = typeof target === "string" ? document.querySelector(target) : target;
+    if (!mount) throw new Error("Notificas.embed: no se encontró el contenedor.");
+
+    var client = null;
+    if (!opts.demo) client = createClient(opts);
+
+    mount.innerHTML = "";
+    var root = el("div", { className: "ntf-embed" });
+    var channel = el("select", null, [
+      el("option", { value: "whatsapp", text: "WhatsApp" }),
+      el("option", { value: "email", text: "Email" }),
+    ]);
+    channel.value = opts.channel === "email" ? "email" : "whatsapp";
+    var name = el("input", { type: "text", autocomplete: "name", maxlength: "120" });
+    var phone = el("input", { type: "tel", autocomplete: "tel", placeholder: "+54911…" });
+    var email = el("input", { type: "email", autocomplete: "email", placeholder: "correo@dominio.com" });
+    var documentId = el("input", { type: "text", maxlength: "20", placeholder: "DNI / CUIT" });
+    var template = el("input", { type: "text", maxlength: "128", placeholder: "notificacion_deuda_180_dias" });
+    if (opts.template) template.value = opts.template;
+    var reference = el("input", { type: "text", maxlength: "128", placeholder: "CLIENTE-12345" });
+    var variables = el("textarea", {
+      placeholder: "nombre=Juan Pérez\ndni=20123456\nmonto=125000",
+    });
+    if (opts.variables && typeof opts.variables === "object") {
+      variables.value = Object.keys(opts.variables)
+        .map(function (k) { return k + "=" + opts.variables[k]; })
+        .join("\n");
+    }
+    var subject = el("input", { type: "text", maxlength: "300", placeholder: "Asunto del correo" });
+    var body = el("textarea", { placeholder: "Texto del mensaje (email)" });
+    var status = el("div");
+    var buttonLabel = opts.buttonLabel || "Enviar notificación";
+    var btn = el("button", { className: "ntf-btn", type: "button", text: buttonLabel });
+
+    function setMsg(ok, text) {
+      status.className = "ntf-msg " + (ok ? "ntf-ok" : "ntf-err");
+      status.textContent = text;
+    }
+
+    function syncChannel() {
+      var wa = channel.value === "whatsapp";
+      phone.parentElement.style.display = wa || opts.showAllFields ? "" : "none";
+      email.parentElement.style.display = !wa || opts.showAllFields ? "" : "none";
+      subject.parentElement.style.display = wa ? "none" : "";
+      body.parentElement.style.display = wa ? "none" : "";
+      template.parentElement.style.display = opts.hideTemplate ? "none" : "";
+    }
+    channel.addEventListener("change", syncChannel);
+
+    btn.addEventListener("click", function () {
+      status.textContent = "";
+      status.className = "";
+      var vars;
+      try {
+        vars = parseVariables(variables.value);
+      } catch (e) {
+        setMsg(false, "Revisá las variables (JSON o clave=valor).");
+        return;
+      }
+      var payload = {
+        channel: channel.value,
+        recipient: {
+          name: name.value.trim() || undefined,
+          phone: phone.value.trim() || undefined,
+          email: email.value.trim() || undefined,
+          document: documentId.value.trim() || undefined,
+        },
+        template: template.value.trim() || undefined,
+        variables: vars,
+        reference: reference.value.trim() || undefined,
+        subject: subject.value.trim() || undefined,
+        body: body.value.trim() || undefined,
+        metadata: opts.metadata,
+      };
+      if (opts.demo) {
+        setMsg(true, "Modo demostración: no se envió nada. En producción usá proxyUrl o una clave de test.");
+        if (typeof opts.onSent === "function") opts.onSent({ id: "ntf_demo", status: "queued", test_mode: true, demo: true });
+        return;
+      }
+      btn.disabled = true;
+      btn.textContent = "Enviando…";
+      client
+        .sendCertifiedNotification(payload)
+        .then(function (res) {
+          var id = res && res.id ? res.id : "";
+          var st = res && res.status ? res.status : "queued";
+          setMsg(true, "Enviada. ID " + id + " · estado " + st + ". Queda constancia técnica de qué se envió, a quién y cuándo.");
+          if (typeof opts.onSent === "function") opts.onSent(res);
+        })
+        .catch(function (err) {
+          setMsg(false, (err && err.message) || "No se pudo enviar.");
+          if (typeof opts.onError === "function") opts.onError(err);
+        })
+        .then(function () {
+          btn.disabled = false;
+          btn.textContent = buttonLabel;
+        });
+    });
+
+    root.appendChild(
+      el("div", { className: "ntf-card" }, [
+        el("div", { className: "ntf-brand" }, [
+          el("div", { className: "ntf-mark", text: "N" }),
+          el("p", { className: "ntf-title", text: opts.title || "Notificación certificada" }),
+        ]),
+        el("p", {
+          className: "ntf-sub",
+          text:
+            opts.subtitle ||
+            "Envía un mensaje y deja constancia de qué salió, a quién y cuándo. No reemplaza una carta documento si la norma pide esa forma.",
+        }),
+        field("Canal", channel),
+        field("Nombre", name),
+        field("Teléfono (WhatsApp)", phone),
+        field("Email", email),
+        field("Documento", documentId),
+        field("Plantilla", template),
+        field("Referencia", reference),
+        field("Variables (clave=valor)", variables),
+        field("Asunto", subject),
+        field("Cuerpo", body),
+        btn,
+        status,
+        el("p", { className: "ntf-foot" }, [
+          document.createTextNode("Instrumento "),
+          el("a", { href: "https://notificas.com.ar/docs/api/embed", text: "Notificas API" }),
+        ]),
+      ])
+    );
+    mount.appendChild(root);
+    syncChannel();
+    return {
+      destroy: function () {
+        mount.innerHTML = "";
+      },
+      client: client,
+    };
+  }
+
+  function autoEmbed() {
+    if (!isBrowser()) return;
+    var nodes = document.querySelectorAll("[data-notificas-embed]");
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      if (node.getAttribute("data-notificas-ready") === "1") continue;
+      var varsRaw = node.getAttribute("data-variables");
+      var variables;
+      try {
+        variables = varsRaw ? JSON.parse(varsRaw) : undefined;
+      } catch (e) {
+        variables = undefined;
+      }
+      embed(node, {
+        proxyUrl: node.getAttribute("data-proxy-url") || undefined,
+        apiKey: node.getAttribute("data-api-key") || undefined,
+        allowBrowserKey: node.getAttribute("data-allow-browser-key") === "true",
+        baseUrl: node.getAttribute("data-base-url") || undefined,
+        channel: node.getAttribute("data-channel") || undefined,
+        template: node.getAttribute("data-template") || undefined,
+        title: node.getAttribute("data-title") || undefined,
+        demo: node.getAttribute("data-demo") === "true",
+        hideTemplate: node.getAttribute("data-hide-template") === "true",
+        buttonLabel: node.getAttribute("data-button-label") || undefined,
+        variables: variables,
+      });
+      node.setAttribute("data-notificas-ready", "1");
+    }
+  }
+
+  if (isBrowser()) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", autoEmbed);
+    } else {
+      autoEmbed();
+    }
+  }
+
+  return {
+    version: VERSION,
+    create: createClient,
+    embed: embed,
+    autoEmbed: autoEmbed,
+    _assertBrowserKeySafe: assertBrowserKeySafe,
+    _parseVariables: parseVariables,
+    _resolveUrl: resolveUrl,
+    _isLiveKey: isLiveKey,
+  };
+});

--- a/docs/examples/gestion-regatas-embed/src/app/api/notificas/[...path]/route.ts
+++ b/docs/examples/gestion-regatas-embed/src/app/api/notificas/[...path]/route.ts
@@ -1,0 +1,102 @@
+/**
+ * Proxy hacia la API pública de Notificas.
+ * El navegador nunca ve NOTIFICAS_API_KEY. Requiere cookie de sesión
+ * abierta por /api/notificas/session (super admin).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import {
+  notificasApiBase,
+  notificasApiConfigured,
+  notificasEmbedCookie,
+  verifyNotificasEmbedSession,
+} from "@/lib/notificas-embed";
+
+const ALLOWED_PREFIXES = ["notifications", "me"];
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxy(request, context);
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxy(request, context);
+}
+
+async function proxy(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  const session = await verifyNotificasEmbedSession(
+    request.cookies.get(notificasEmbedCookie.name)?.value
+  );
+  if (!session) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "unauthorized",
+          message: "Sesión de Notificas vencida. Recargá la página.",
+        },
+      },
+      { status: 401 }
+    );
+  }
+
+  if (!notificasApiConfigured()) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "misconfigured",
+          message: "Falta NOTIFICAS_API_KEY en .env.local de gestión-regatas.",
+        },
+      },
+      { status: 500 }
+    );
+  }
+
+  const { path } = await context.params;
+  const segments = path ?? [];
+  const first = segments[0] ?? "";
+  if (!ALLOWED_PREFIXES.includes(first)) {
+    return NextResponse.json(
+      { error: { code: "forbidden_path", message: "Ruta no permitida." } },
+      { status: 403 }
+    );
+  }
+
+  const search = request.nextUrl.search;
+  const target = `${notificasApiBase()}/${segments.map(encodeURIComponent).join("/")}${search}`;
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${process.env.NOTIFICAS_API_KEY!.trim()}`);
+  headers.set("Accept", "application/json");
+  const contentType = request.headers.get("content-type");
+  if (contentType) headers.set("Content-Type", contentType);
+  const idempotency = request.headers.get("Idempotency-Key");
+  if (idempotency) headers.set("Idempotency-Key", idempotency);
+
+  const init: RequestInit = { method: request.method, headers };
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = await request.text();
+  }
+
+  try {
+    const upstream = await fetch(target, init);
+    const body = await upstream.text();
+    return new NextResponse(body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type": upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "No se pudo contactar Notificas.";
+    return NextResponse.json(
+      { error: { code: "upstream_unreachable", message } },
+      { status: 502 }
+    );
+  }
+}

--- a/docs/examples/gestion-regatas-embed/src/app/api/notificas/session/route.ts
+++ b/docs/examples/gestion-regatas-embed/src/app/api/notificas/session/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Abre una sesión corta (cookie httpOnly) para que el widget de Notificas
+ * pueda hablar con el proxy sin exponer la API key ni el token de Firebase.
+ * Solo super admin.
+ */
+import { NextResponse } from "next/server";
+import { verifySuperAdmin } from "@/lib/auth-server";
+import {
+  notificasApiConfigured,
+  notificasEmbedCookie,
+  signNotificasEmbedSession,
+} from "@/lib/notificas-embed";
+
+export async function GET(request: Request) {
+  const admin = await verifySuperAdmin(request.headers.get("Authorization"));
+  if (!admin) {
+    return NextResponse.json({ error: { message: "No autorizado" } }, { status: 401 });
+  }
+  return NextResponse.json({ ok: true, configured: notificasApiConfigured() });
+}
+
+export async function POST(request: Request) {
+  const admin = await verifySuperAdmin(request.headers.get("Authorization"));
+  if (!admin) {
+    return NextResponse.json({ error: { message: "No autorizado" } }, { status: 401 });
+  }
+
+  const token = await signNotificasEmbedSession(admin.uid);
+  const res = NextResponse.json({ ok: true, configured: notificasApiConfigured() });
+  res.cookies.set(notificasEmbedCookie.name, token, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: notificasEmbedCookie.maxAge,
+    secure: process.env.NODE_ENV === "production",
+  });
+  return res;
+}

--- a/docs/examples/gestion-regatas-embed/src/app/dashboard/admin/notificas/page.tsx
+++ b/docs/examples/gestion-regatas-embed/src/app/dashboard/admin/notificas/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, Loader2, Send } from "lucide-react";
+import { useUserProfile, useFirebase } from "@/firebase";
+import { getAuth } from "firebase/auth";
+
+declare global {
+  interface Window {
+    Notificas?: {
+      embed: (
+        target: string | Element,
+        options?: Record<string, unknown>
+      ) => { destroy: () => void };
+    };
+  }
+}
+
+export default function NotificasEmbedPage() {
+  const router = useRouter();
+  const { app } = useFirebase();
+  const { isSuperAdmin, isReady } = useUserProfile();
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [configured, setConfigured] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isReady) return;
+    if (!isSuperAdmin) {
+      router.replace("/dashboard");
+    }
+  }, [isReady, isSuperAdmin, router]);
+
+  useEffect(() => {
+    if (!isReady || !isSuperAdmin || !app) return;
+    let cancelled = false;
+
+    async function prepare() {
+      try {
+        const auth = getAuth(app);
+        const user = auth.currentUser;
+        if (!user) {
+          setError("No estás logueado.");
+          setStatus("error");
+          return;
+        }
+        const token = await user.getIdToken();
+        const res = await fetch("/api/notificas/session", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = (await res.json().catch(() => ({}))) as {
+          configured?: boolean;
+          error?: { message?: string };
+        };
+        if (!res.ok) {
+          setError(data.error?.message || `Error ${res.status}`);
+          setStatus("error");
+          return;
+        }
+        if (cancelled) return;
+        setConfigured(Boolean(data.configured));
+        setStatus("ready");
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "No se pudo abrir la sesión de Notificas.");
+        setStatus("error");
+      }
+    }
+
+    void prepare();
+    return () => {
+      cancelled = true;
+    };
+  }, [isReady, isSuperAdmin, app]);
+
+  useEffect(() => {
+    if (status !== "ready") return;
+    const existing = document.querySelector<HTMLScriptElement>('script[data-notificas-sdk="v1"]');
+    const mount = () => {
+      const host = document.querySelector("#notificas-regatas-embed");
+      if (!host || host.childElementCount > 0 || !window.Notificas) return;
+      window.Notificas.embed("#notificas-regatas-embed", {
+        proxyUrl: configured ? "/api/notificas" : undefined,
+        demo: !configured,
+        channel: "whatsapp",
+        template: "notificacion_deuda_180_dias",
+        title: "Notificas · Regatas+",
+        buttonLabel: configured ? "Enviar notificación certificada" : "Enviar (demo)",
+      });
+    };
+
+    if (existing && window.Notificas) {
+      mount();
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = "/sdk/v1/notificas.js";
+    script.async = true;
+    script.dataset.notificasSdk = "v1";
+    script.onload = mount;
+    document.body.appendChild(script);
+  }, [status, configured]);
+
+  if (!isReady || !isSuperAdmin) return null;
+
+  return (
+    <div className="container max-w-xl py-6">
+      <Button variant="ghost" size="sm" className="mb-4 -ml-2 text-muted-foreground" asChild>
+        <Link href="/dashboard/admin/config">
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Configuración global
+        </Link>
+      </Button>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Send className="h-6 w-6 text-primary" />
+            <CardTitle>Probar Notificas</CardTitle>
+          </div>
+          <CardDescription>
+            Esta es la misma ventana que se inserta en sitios de terceros. La API key queda en el
+            servidor de Regatas+; el widget solo habla con <code>/api/notificas</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
+            La constancia es evidencia técnica del envío. No es firma digital, acto notarial ni
+            carta documento.
+          </div>
+
+          {status === "loading" ? (
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Preparando el widget…
+            </p>
+          ) : null}
+
+          {status === "error" ? (
+            <p className="text-sm text-destructive">{error}</p>
+          ) : null}
+
+          {status === "ready" && !configured ? (
+            <p className="text-sm text-muted-foreground">
+              Falta <code>NOTIFICAS_API_KEY</code> en <code>.env.local</code>. El widget está en modo
+              demo (no envía). Generá una clave en Notificas (<code>/admin/api-keys</code>) y
+              reiniciá <code>npm run dev</code>. Para pegarle a un Notificas local usá{" "}
+              <code>NOTIFICAS_API_BASE=http://localhost:9006/api/v1</code>.
+            </p>
+          ) : null}
+
+          {status === "ready" && configured ? (
+            <p className="text-sm text-muted-foreground">
+              Listo para enviar de verdad. Completá destinatario y plantilla, y usá un teléfono o
+              email que puedas verificar.
+            </p>
+          ) : null}
+
+          <div id="notificas-regatas-embed" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/docs/examples/gestion-regatas-embed/src/lib/notificas-embed.ts
+++ b/docs/examples/gestion-regatas-embed/src/lib/notificas-embed.ts
@@ -1,0 +1,48 @@
+import { SignJWT, jwtVerify } from "jose";
+
+const COOKIE_NAME = "notificas_embed";
+const COOKIE_MAX_AGE = 30 * 60;
+
+function embedSecret() {
+  const raw =
+    process.env.NOTIFICAS_EMBED_SECRET?.trim() ||
+    process.env.QR_JWT_SECRET?.trim() ||
+    "dev-notificas-embed";
+  return new TextEncoder().encode(raw);
+}
+
+export function notificasApiConfigured(): boolean {
+  return Boolean(process.env.NOTIFICAS_API_KEY?.trim());
+}
+
+export function notificasApiBase(): string {
+  return (process.env.NOTIFICAS_API_BASE?.trim() || "https://notificas.com.ar/api/v1").replace(
+    /\/$/,
+    ""
+  );
+}
+
+export async function signNotificasEmbedSession(uid: string): Promise<string> {
+  return new SignJWT({ uid, scope: "notificas_embed" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime(`${COOKIE_MAX_AGE}s`)
+    .sign(embedSecret());
+}
+
+export async function verifyNotificasEmbedSession(
+  token: string | undefined
+): Promise<{ uid: string } | null> {
+  if (!token) return null;
+  try {
+    const { payload } = await jwtVerify(token, embedSecret());
+    if (payload.scope !== "notificas_embed" || typeof payload.uid !== "string") return null;
+    return { uid: payload.uid };
+  } catch {
+    return null;
+  }
+}
+
+export const notificasEmbedCookie = {
+  name: COOKIE_NAME,
+  maxAge: COOKIE_MAX_AGE,
+} as const;

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -210,6 +210,8 @@ El proxy reenvía `/api/notificas/*` → `https://notificas.com.ar/api/v1/*`. Ej
 - `docs/examples/express-proxy.js`
 - `docs/examples/embed.html`
 
+Kit para pegar el widget en **gestión-regatas** (Regatas+): `docs/examples/gestion-regatas-embed/` (parche `apply-in-gestion-regatas.patch`). Página de prueba: `/dashboard/admin/notificas`.
+
 Demo sin API: `Notificas.embed("#el", { demo: true })` o `data-demo="true"`.
 
 ## Preparado para agentes / iPaaS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué es

Kit para meter la **ventana de Notificas** en **gestión-regatas** (Regatas+) y probar un envío real desde ese panel.

Este entorno no puede pushear a `abengolea/gestion-regatas` (403). El cambio va como parche aplicable en `C:\DEV\gestion-regatas`.

## Cómo usarlo

En la PC:

```bat
cd C:\DEV\gestion-regatas
git am C:\DEV\notificas\docs\examples\gestion-regatas-embed\apply-in-gestion-regatas.patch
```

En `.env.local` de gestión-regatas:

```
NOTIFICAS_API_KEY=ntf_test_...
NOTIFICAS_API_BASE=http://localhost:9006/api/v1
```

Levantá Notificas en `:9006` y Regatas+ en `:9003`. Entrá como super admin a:

`http://localhost:9003/dashboard/admin/notificas`

La API key no va al navegador: el widget habla con `/api/notificas` en Regatas, y el servidor reenvía a Notificas.

Si falta la key, el widget igual se ve en modo demo (no envía).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25300f91-43db-46fd-b3b7-6b5f203b9d1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25300f91-43db-46fd-b3b7-6b5f203b9d1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

